### PR TITLE
Make CSS easier to read

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,4 +1,5 @@
-/* Main Page CSS */
+/* MAIN PAGE CSS */
+
 .container {
     width: 95%;
 }
@@ -17,25 +18,35 @@
 
 .thumb {
     margin: 1px 1px -3px 1px;
-    padding: 0px 0px 0px 0px;
+    padding: 0 0 0 0;
     width: 150px;
     height: 150px;
 }
 
 .col-centered {
-    display:inline-block;
-    float:none;
-    text-align:left;
-    margin-right:-4px;
+    display: inline-block;
+    float: none;
+    text-align: left;
+    margin-right: -4px;
 }
 
 .row-centered {
-    text-align:center;
+    text-align :center;
 }
 
 .plotbox {
     text-align: center;
 }
+
+/* GENERAL PLOT CSS */
+
+.axis path, .axis line {
+    fill: none;
+    stroke: black;
+    shape-rendering: crispEdges;
+}
+
+/* HISTOGRAM CSS */
 
 .bar rect {
     fill: steelblue;
@@ -44,28 +55,45 @@
 
 .bar text {
     font: 10px sans-serif;
-    fill: #fff;
+    fill: white;
 }
+
+/* LINEPLOT CSS */
 
 .axis path, .axis line {
     fill: none;
-    stroke: #000;
+    stroke: black;
     shape-rendering: crispEdges;
 }
 
 .line {
     fill: none;
     stroke: steelblue;
-    stroke-width: 1.5px;
+    stroke-width: 2px;
 }
 
-/* Tooltip CSS */
+/* SCATTERPLOT CSS */
+
+.scatterpt {
+    fill: steelblue;
+    stroke: white;
+}
+
+.activept {
+    fill: red;
+}
+
+.neighbourpt {
+    fill: yellow;
+}
+
+/* TOOLTIP CSS */
 
 .d3-tip {
     font-weight: bold;
     padding: 8px;
     background: rgba(0, 0, 0, 0.8);
-    color: #fff;
+    color: white;
     border-radius: 2px;
 }
 
@@ -82,7 +110,6 @@
     text-align: center;
 }
 
-/* Style northward tooltips differently */
 .d3-tip.n:after {
     margin: -3px 0 0 0;
     top: 100%;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -24,7 +24,7 @@
     height: 150px;
 }
 
-/* Centered colums for grid display in Nebula */
+/* Centered columns for grid display in Nebula */
 .col-centered {
     display: inline-block;
     float: none;
@@ -34,7 +34,7 @@
 
 /* Centered rows for grid display in Nebula */
 .row-centered {
-    text-align :center;
+    text-align: center;
 }
 
 /* Plot all D3 SVGs to center of their divs */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8,6 +8,7 @@
     border-radius: 0 !important;
 }
 
+/* Create some space between tab and tab content */
 .tab-pane {
     margin-top: 10px;
 }
@@ -23,6 +24,7 @@
     height: 150px;
 }
 
+/* Centered columns for grid display in Nebula */
 .col-centered {
     display: inline-block;
     float: none;
@@ -30,10 +32,12 @@
     margin-right: -4px;
 }
 
+/* Centered rows for grid display in Nebula */
 .row-centered {
     text-align :center;
 }
 
+/* Plot all D3 SVGs to center of their divs */
 .plotbox {
     text-align: center;
 }

--- a/public/js/viz-scatterplot.js
+++ b/public/js/viz-scatterplot.js
@@ -58,11 +58,9 @@ var renderScatterplot = function(sampleData, featureNames) {
             return yScale(d['pca'][1]);
         })
         .attr('r', 5)
-        .attr('fill', 'steelblue')
-        .attr('stroke', 'white')
         .classed('scatterpt', true)
         .classed('activept', false)
-        .classed('neighbour', false)
+        .classed('neighbourpt', false)
         .attr('id', function(d) {
           return d['_id'];
         })
@@ -84,30 +82,26 @@ var renderScatterplot = function(sampleData, featureNames) {
       // reset class and attr of prev active point
       d3.selectAll('.activept')
         .classed('activept', false)
-        .classed('neighbour', false)
+        .classed('neighbourpt', false)
         .transition()
         .duration(125)
-        .attr('r', 5)
-        .attr('fill', 'steelblue')
-        .attr('stroke', 'white');
+        .attr('r', 5);
 
-      d3.selectAll('.neighbour')
-        .classed('neighbour', false)
-        .transition()
-        .duration(125)
+      d3.selectAll('.neighbourpt')
+        .classed('neighbourpt', false)
         .attr('r', 5)
-        .attr('fill', 'steelblue')
-        .attr('stroke', 'white');
+        .transition()
+        .duration(125);
 
       // add neighbour class to all neighbours
       var neighbours = selection.data()[0]['neighbours'];
       for(var i = 1 ; i < neighbours.length; i++) {
         console.log(d3.select('[id=' + neighbours[i] + ']'));
         d3.select('[id=' + neighbours[i] + ']')
-          .classed('neighbour', true)
+          .classed('neighbourpt', true)
           .transition()
           .duration(125)
-          .attr('fill', 'yellow')
+          .attr('r', 5);
       }
 
       // set class and attr of new active point
@@ -115,10 +109,7 @@ var renderScatterplot = function(sampleData, featureNames) {
         .classed('activept', true)
         .transition()
         .duration(125)
-        .attr('r', 7)
-        .attr('fill', 'red')
-        .attr('stroke', 'white');
-
+        .attr('r', 7);
 
     };
 


### PR DESCRIPTION
Added a few things to make the CSS a little easier to read:

* Add comments to better separate between sections
* Add comments to explain some of the less obvious parts
* More consistency with colour selections and formatting

Also a small change to the scatterplot function..

* Use CSS to style scatterplot points where possible, instead of using the D3 selector.

@jni - Not sure if you'll be notified of this so pinging you just in case :)