### PR TITLE
Add basic Grunt task runner

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "huscinterface",
+    "name": "microscopium-ui",
     "version": "0.0.1",
     "directory": "public/bower_components",
     "dependencies": {
@@ -7,7 +7,6 @@
         "d3": "latest",
         "d3-tip": "latest",
         "jquery": "latest",
-        "jquery-csv": "latest",
         "spin.js": "latest"
     }
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -9,7 +9,12 @@ module.exports = function(grunt) {
             }
         },
         jshint: {
-            all: ['*.js', 'public/js/*.js']
+            all: ['*.js', 'public/js/*.js'],
+            options: {
+                white: false,
+                indent: 4,
+                force: true
+            }
         },
         watch: {
             scripts: {
@@ -22,8 +27,6 @@ module.exports = function(grunt) {
             }
         }
     });
-
-    grunt.option('force', true);
 
     grunt.loadNpmTasks('grunt-express-server');
     grunt.loadNpmTasks('grunt-contrib-jshint');

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,34 @@
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+        express: {
+            dev: {
+                options: {
+                    script: 'server.js'
+                }
+            }
+        },
+        jshint: {
+            all: ['*.js', 'public/js/*.js']
+        },
+        watch: {
+            scripts: {
+                files: ['**.js'],
+                tasks: ['jshint', 'express:dev'],
+                options: {
+                    livereload: true,
+                    spawn: false
+                }
+            }
+        }
+    });
+
+    grunt.option('force', true);
+
+    grunt.loadNpmTasks('grunt-express-server');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+
+    grunt.registerTask('default', ['express:dev', 'jshint:all', 'watch']);
+
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "grunt": "~0.4.5",
-        "grunt-contrib-jshint": "~0.1.0",
+        "grunt-contrib-jshint": "~0.8.0",
         "grunt-contrib-watch": "~0.6.1",
         "grunt-express-server": "~0.4.0"
     }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
-    "name": "huscinterface",
+    "name": "microscopium-ui",
     "main": "server.js",
     "dependencies": {
         "express": "~4.0.0",
         "mongoose": "~3.8.0",
         "morgan": "~1.0.0",
         "body-parser": "~1.0.0"
+    },
+    "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-contrib-jshint": "~0.1.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-express-server": "~0.4.0"
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <!-- DEPENDENCIES -->
     <script src="components/jquery/dist/jquery.js"></script>
-    <script src="components/jquery-csv/src/jquery.csv.js"></script>
     <link rel="stylesheet" href="components/bootstrap/dist/css/bootstrap.css">
     <script src="components/bootstrap/dist/js/bootstrap.js"></script>
     <script src="components/d3/d3.js"></script>


### PR DESCRIPTION
Summary of the changes here ..

* Add Grunt: runs JSHint and restarts the server whenever any of the project JS files are changed. 
* Remove the jQuery CSV plugin as it's no longer needed.
* Rename the project in ``bower.json`` and ``package.json``

This throws about 30 JSHint warnings (not too bad). The next PR will fix these up, and just generally make the code cleaner and easier to maintain. Once that's done testing can be added to the workflow.