### PR TITLE
Gene tooltips

### DIFF
--- a/public/js/viz-scattercluster.js
+++ b/public/js/viz-scattercluster.js
@@ -117,15 +117,28 @@ var renderScatterCluster = function(sampleData) {
         .text('PC2');
 
     function redraw(newk) {
-        console.log(svg.selectAll('.clusterpt'));
+
+        //reset tooltips
+        tip = d3.tip()
+            .attr('class', 'd3-tip')
+            .offset([-10, 0])
+            .html(function(d) {
+                return "<p><strong>ID: </strong>" + d._id + "</p>" +
+                    "<p><strong>Gene: </strong>" + d.gene_name + "</p>" +
+                    "<p><strong>Cluster: </strong>" + (d.cluster_member[newk-clusterMin] + 1) + "</span></p>";
+            });
+
+        d3.selectAll('.d3-tip').remove();
+        d3.select('#scattercluster').append('svg').call(tip);
+
+        // recolour points
         svg.selectAll('circle')
             .data(sampleData)
             .attr('fill', function(d) {
                 var cluster_id = d.cluster_member[newk-clusterMin];
                 return colourScale(cluster_id);
-            });
+            })
+            .on('mouseover', tip.show)
+            .on('mouseout', tip.hide);
     }
-
-
-
 };

--- a/public/js/viz-scattercluster.js
+++ b/public/js/viz-scattercluster.js
@@ -57,7 +57,8 @@ var renderScatterCluster = function(sampleData) {
         .offset([-10, 0])
         .html(function(d) {
             return "<p><strong>ID: </strong>" + d._id + "</p>" +
-                "<p><strong>Cluster: </strong>" + (d.cluster_member[clusterMid-clusterMin] + 1) + "</p>";
+                "<p><strong>Gene: </strong>" + d.gene_name + "</p>" +
+                "<p><strong>Cluster: </strong>" + (d.cluster_member[clusterMid-clusterMin] + 1) + "</span></p>";
         });
 
     // setup canvas

--- a/public/js/viz-scatterplot.js
+++ b/public/js/viz-scatterplot.js
@@ -38,7 +38,8 @@ var renderScatterplot = function(sampleData, featureNames) {
         .attr('class', 'd3-tip')
         .offset([-10, 0])
         .html(function(d) {
-            return "<p><strong>ID: </strong>" + d._id + "</span></p>";
+            return "<p><strong>ID: </strong>" + d._id + "</span></p>" +
+                   "<p><strong>Gene: </strong>" + d.gene_name + "</span></p>";
         });
 
     // setup canvas


### PR DESCRIPTION
* Tooltips now show the gene associated with the sample (where available)
* Fixed a bug that was preventing the tooltips from showing the updated cluster membership ID after the number of clusters was changed on the slider.