### PR TITLE
Update initial DB query on pageload

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -35,6 +35,8 @@ module.exports = function(app) {
     app.get('/api/samples/:screen', function(req, res) {
         Sample
         .find({ 'screen': req.params.screen })
+        .select('_id row col gene_name feature_vector_std ' +
+                'pca cluster_member neighbours')
         .exec(resHandler(res));
     });
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -35,7 +35,7 @@ module.exports = function(app) {
     app.get('/api/samples/:screen', function(req, res) {
         Sample
         .find({ 'screen': req.params.screen })
-        .select('_id row col gene_name feature_vector_std ' +
+        .select('_id row column gene_name feature_vector_std ' +
                 'pca cluster_member neighbours')
         .exec(resHandler(res));
     });

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -26,6 +26,7 @@ var selectScreen = function(screen_id) {
     var featureNames = [];
     var sampleData = [];
     var screenData = [];
+    $('.nav-tabs a[href="#home"]').tab('show');
     $('#page-overlay').spin('large', '#000');
     $('#page-overlay').addClass('load-overlay');
     $.when(

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3,7 +3,7 @@ var getFeatureRow = function(json, feature) {
     var n_features = json.length;
     var feature_row = [];
     for(var i = 0; i < n_features; i++) {
-        feature_row.push(json[i].feature_vector[feature]);
+        feature_row.push(json[i].feature_vector_std[feature]);
     }
     return feature_row;
 };

--- a/public/js/viz-lineplot.js
+++ b/public/js/viz-lineplot.js
@@ -149,7 +149,7 @@ var renderLinePlot = function(sampleData, featureNames, sample) {
         .attr('x', width/2)
         .attr('y', -5)
         .style('text-anchor', 'middle')
-        .text(sampleData[sample].id);
+        .text(sampleData[sample]._id);
 
     // draw activeLine
     updateActiveLine(activeFeature);

--- a/public/js/viz-scattercluster.js
+++ b/public/js/viz-scattercluster.js
@@ -1,5 +1,8 @@
 var renderScatterCluster = function(sampleData) {
 
+    // delete any scatterplots already plotted
+    d3.select('#scattercluster > svg').remove();
+
     // setup slider control
     var clusterMin = 2;
     var clusterMax = 20;
@@ -17,9 +20,6 @@ var renderScatterCluster = function(sampleData) {
         redraw(this.value);
         $('#cluster-number').html(this.value);
     });
-
-    // delete any scatterplots already plotted
-    d3.select('#scattercluster > svg').remove();
 
     // find min/max for each axis
     var xMin = d3.min(sampleData, function(d) { return d.pca[0]; });


### PR DESCRIPTION
The first of a couple of PRs that will add the filtering function to the UI.. this one is fairly simple!

* Reduce the number of fields returned by Mongo when a screen is selected. This greatly reduces loading times.
* Fix a bug that was preventing the title from showing in the lineplot
* Fix a bug that was causing the cluster scatterplot to sometimes render to the wrong div
* Redirect users to the summary screen whenever the active screen is changed