### PR TITLE
Update express and middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
     "name": "microscopium-ui",
     "main": "server.js",
     "dependencies": {
-        "express": "~4.0.0",
-        "mongoose": "~3.8.0",
-        "morgan": "~1.0.0",
-        "body-parser": "~1.0.0",
+        "body-parser": "~1.12.0",
+        "compression": "~1.4.3",
         "d3": "~3.5.5",
         "d3-tip": "~0.6.7",
-        "spin.js": "~2.0.2",
+        "express": "~4.12.0",
         "lodash": "~3.2.0",
-        "lodash-deep": "~1.5.3"
+        "lodash-deep": "~1.5.3",
+        "mongoose": "~4.0.0",
+        "morgan": "~1.5.0",
+        "spin.js": "~2.0.2"
     },
     "devDependencies": {
         "grunt": "~0.4.5",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 // modules
 var express = require('express');
+var compression = require('compression')
 var app = express();
 var logger = require('morgan');
 var bodyParser = require('body-parser');
@@ -11,7 +12,11 @@ mongoose.connect(db.url);
 
 // setup app
 app.use(logger('dev'));
-app.use(bodyParser());
+app.use(bodyParser.urlencoded({
+    extended: true
+}));
+app.use(bodyParser.json());
+app.use(compression());
 app.use(express.static(__dirname + '/public'));
 
 // routes


### PR DESCRIPTION
* Use the latest version of the express framework
* Use latest version of morgan and bodyparser
* Add the compress middleware -- uses gzip when sending responses from the server. Given the server will be sending lots of JSON (a plain-text format), it makes lots of sense to use this. At the moment it's just using the default settings which applies a mid-level of compression to all responses, but these can be customized so more compression is used for larger responses.