### PR TITLE
[WIP] Refactor interface to show all plots in one tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ var Image = {
         _id: ObjectID, // Mongo generated unique ID for this image
         sample_id: String, // The _id of the sample corresponding to this image.
         image_full: String, // The fullsize image.
-        image_full: String, // A large preview image, 512px wide.
+        image_large: String, // A large preview image, 512px wide.
         image_thumb: String // A smalller, thumbnail sized preview image, 150px wide.
     }
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Each image saved in document with format:
 var Image = {
         _id: ObjectID, // Mongo generated unique ID for this image
         sample_id: String, // The _id of the sample corresponding to this image.
-        image_full: String, // BinData of image
-        image_thumb: String // BinData of image (thumbnail)
+        image_full: String, // The fullsize image.
+        image_full: String, // A large preview image, 512px wide.
+        image_thumb: String // A smalller, thumbnail sized preview image, 150px wide.
     }
 ```

--- a/app/routes.js
+++ b/app/routes.js
@@ -62,6 +62,21 @@ module.exports = function(app) {
             .exec(resHandler(res))
     });
 
+    // get all neighbours
+    app.get('/api/sample/neighbours/:id', function(req, res) {
+        Sample
+            .find({ '_id': req.params.id })
+            .select('neighbours')
+            .exec(function(err, data) {
+                Sample.find({
+                    '_id': { $in: data[0].neighbours }
+                })
+                .exec(function(err, data) {
+                    res.send(data);
+                });
+            })
+    });
+
     // get value from sample document
     app.get('/api/sample/:key/:id', function(req, res) {
       Sample
@@ -78,14 +93,19 @@ module.exports = function(app) {
         .exec(resHandler(res));
     });
 
-    // get image thumbnails
-    app.get('/api/images/', function(req, res) {
-      Image
-        .find({
-          'sample_id': { $in: req.query.sample_ids }
-        })
-        .select('image_thumb sample_id')
-        .exec(resHandler(res));
+    // get thumbnails for all neighbour images
+    app.get('/api/images/:id', function(req, res) {
+        Sample
+            .find({ '_id': req.params.id })
+            .select('neighbours')
+            .exec(function(err, data) {
+                Image
+                    .find({
+                        'sample_id': { $in: data[0].neighbours }
+                    })
+                    .select('sample_id image_thumb')
+                    .exec(resHandler(res));
+            })
     });
 
     // default route

--- a/app/routes.js
+++ b/app/routes.js
@@ -51,7 +51,7 @@ module.exports = function(app) {
         Sample
         .find({ 'screen': req.params.screen })
         .select('_id row column plate gene_name feature_vector_std ' +
-                'pca cluster_member neighbours')
+                'pca_vector neighbours')
         .exec(resHandler(res));
     });
 
@@ -85,11 +85,11 @@ module.exports = function(app) {
         .exec(resHandler(res))
     });
 
-    //get fullsize image
+    //get large image
     app.get('/api/image/:id', function(req, res) {
         Image
             .find({ 'sample_id': req.params.id })
-        .select('sample_id image_full')
+        .select('sample_id image_large')
         .exec(resHandler(res));
     });
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -21,6 +21,10 @@
     margin-top: 50px;
 }
 
+.sb-active {
+    overflow: hidden;
+}
+
 .panel {
     background-color: #222222;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -81,15 +81,15 @@
 .thumb {
     margin: 1px 1px -3px 1px;
     padding: 0 0 0 0;
-    width: 150px;
-    height: 150px;
+    width: 100px;
+    height: 100px;
 }
 
 .selected-image-display {
     margin: 1px 1px -3px 1px;
     padding: 0 0 0 0;
-    width: 300px;
-    height: 300px;
+    width: 250px;
+    height: 250px;
 }
 
 /* Centered columns for grid display in Nebula */
@@ -107,7 +107,7 @@
 
 /* Plot all D3 SVGs to center of their divs */
 .plotbox {
-    text-align: center;
+    text-align: left;
 }
 
 /* GENERAL PLOT CSS */
@@ -147,7 +147,7 @@
 /* NEIGHBOUR PLOT CSS */
 
 .gallery {
-    height: 500px;
+    height: 675px;
     overflow: scroll;
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,5 +1,10 @@
 /* MAIN PAGE CSS */
 
+#image-column {
+    overflow: scroll;
+    height: 0;
+}
+
 .load-overlay {
     pointer-events: none;
 }
@@ -85,15 +90,11 @@
 .thumb {
     margin: 1px 1px -3px 1px;
     padding: 0 0 0 0;
-    width: 100px;
-    height: 100px;
 }
 
 .selected-image-display {
     margin: 1px 1px -3px 1px;
     padding: 0 0 0 0;
-    width: 250px;
-    height: 250px;
 }
 
 /* Centered columns for grid display in Nebula */
@@ -149,11 +150,6 @@
 }
 
 /* NEIGHBOUR PLOT CSS */
-
-.gallery {
-    height: 675px;
-    overflow: scroll;
-}
 
 .pcaplot {
     height: 500px;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -106,11 +106,6 @@
     text-align: center;
 }
 
-/* Plot all D3 SVGs to center of their divs */
-.plotbox {
-    text-align: left;
-}
-
 /* GENERAL PLOT CSS */
 
 .axis path, .axis line {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -87,14 +87,10 @@
     font-weight: bold;
 }
 
-.thumb {
+.sample-image {
     margin: 1px 1px -3px 1px;
     padding: 0 0 0 0;
-}
-
-.selected-image-display {
-    margin: 1px 1px -3px 1px;
-    padding: 0 0 0 0;
+    height: 100%;
 }
 
 /* Centered columns for grid display in Nebula */

--- a/public/index.html
+++ b/public/index.html
@@ -48,15 +48,15 @@
         <div class="row">
             <div class="col-lg-8" id="plot-column">
                 <div class="row">
-                    <div class="row plotbox" id="neighbourplot"></div>
+                    <div class="row" id="neighbourplot"></div>
                 </div>
                 <div class="row">
                     <div class="col-lg-6">
-                        <div class="row plotbox" id="lineplot">
+                        <div class="row"  id="lineplot">
                         </div>
                     </div>
                     <div class="col-lg-6">
-                        <div class="row plotbox" id="histplot">
+                        <div class="row" id="histplot">
                         </div>
                     </div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -45,164 +45,166 @@
     </nav>
     <!-- PAGE CONTENT -->
     <div class="container">
-        <div class="col-lg-8">
-            <div class="row">
-                <div class="row plotbox" id="neighbourplot"></div>
+        <div class="row" id="main-row">
+            <div class="col-lg-8" id="plot-column">
+                <div class="row">
+                    <div class="row plotbox" id="neighbourplot"></div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-6">
+                        <div class="row plotbox" id="lineplot">
+                        </div>
+                    </div>
+                    <div class="col-lg-6">
+                        <div class="row plotbox" id="histplot">
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div class="row">
-                <div class="col-lg-6">
-                    <div class="row plotbox" id="lineplot">
+            <div class="col-lg-4" id="image-column">
+                <div class="col-lg-12">
+                    <div class="row row-centered">
+                        <div class="col-lg-12 col-centered selected-image-display">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-0" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                </div>
-                <div class="col-lg-6">
-                    <div class="row plotbox" id="histplot">
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-1" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-2" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-3" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-lg-4">
-            <div class="col-lg-12 gallery">
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered selected-image-display">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-0" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-4" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-5" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-6" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-12 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-1" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-7" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-8" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-9" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-2" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-10" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-11" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-12" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-3" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-13" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-14" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-15" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-4" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-16" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-17" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-18" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-5" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-19" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-20" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-21" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-6" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-7" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-8" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-9" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-10" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-11" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-12" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-13" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-14" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-15" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-16" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-17" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-18" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-19" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-20" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-21" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                </div>
-                <div class="row-centered">
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-22" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-23" class="img-responsive" src="" alt="">
-                        </a>
-                    </div>
-                    <div class="col-lg-3 col-centered thumb">
-                        <a class="thumbnail" href="#">
-                            <img id="nebula-24" class="img-responsive" src="" alt="">
-                        </a>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-22" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-23" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered thumb">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-24" class="img-responsive" src="" alt="">
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
     </nav>
     <!-- PAGE CONTENT -->
     <div class="container">
-        <div class="row" id="main-row">
+        <div class="row">
             <div class="col-lg-8" id="plot-column">
                 <div class="row">
                     <div class="row plotbox" id="neighbourplot"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -64,145 +64,145 @@
             <div class="col-lg-4" id="image-column">
                 <div class="col-lg-12">
                     <div class="row row-centered">
-                        <div class="col-lg-12 col-centered selected-image-display">
+                        <div class="col-lg-12 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-0" class="img-responsive" src="" alt="">
+                                <img id="nebula-0" src="" alt="">
                             </a>
                         </div>
                     </div>
                     <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-1" class="img-responsive" src="" alt="">
+                                <img id="nebula-1" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-2" class="img-responsive" src="" alt="">
+                                <img id="nebula-2" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-3" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-4" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-5" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-6" class="img-responsive" src="" alt="">
+                                <img id="nebula-3" src="" alt="">
                             </a>
                         </div>
                     </div>
                     <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-7" class="img-responsive" src="" alt="">
+                                <img id="nebula-4" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-8" class="img-responsive" src="" alt="">
+                                <img id="nebula-5" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-9" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-10" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-11" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-12" class="img-responsive" src="" alt="">
+                                <img id="nebula-6" src="" alt="">
                             </a>
                         </div>
                     </div>
                     <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-13" class="img-responsive" src="" alt="">
+                                <img id="nebula-7" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-14" class="img-responsive" src="" alt="">
+                                <img id="nebula-8" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-15" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-16" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-17" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-18" class="img-responsive" src="" alt="">
+                                <img id="nebula-9" src="" alt="">
                             </a>
                         </div>
                     </div>
                     <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-19" class="img-responsive" src="" alt="">
+                                <img id="nebula-10" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-20" class="img-responsive" src="" alt="">
+                                <img id="nebula-11" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-21" class="img-responsive" src="" alt="">
+                                <img id="nebula-12" src="" alt="">
                             </a>
                         </div>
                     </div>
                     <div class="row row-centered">
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-22" class="img-responsive" src="" alt="">
+                                <img id="nebula-13" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-23" class="img-responsive" src="" alt="">
+                                <img id="nebula-14" src="" alt="">
                             </a>
                         </div>
-                        <div class="col-lg-4 col-centered thumb">
+                        <div class="col-lg-4 col-centered sample-image">
                             <a class="thumbnail" href="#">
-                                <img id="nebula-24" class="img-responsive" src="" alt="">
+                                <img id="nebula-15" src="" alt="">
+                            </a>
+                        </div>
+                    </div>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-16" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-17" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-18" src="" alt="">
+                            </a>
+                        </div>
+                    </div>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-19" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-20" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-21" src="" alt="">
+                            </a>
+                        </div>
+                    </div>
+                    <div class="row row-centered">
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-22" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-23" src="" alt="">
+                            </a>
+                        </div>
+                        <div class="col-lg-4 col-centered sample-image">
+                            <a class="thumbnail" href="#">
+                                <img id="nebula-24" src="" alt="">
                             </a>
                         </div>
                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -32,9 +32,6 @@
                     <ul class="dropdown-menu" id="screen-menu" role="menu">
                     </ul>
                 </li>
-                <li class="navbar-item hidden">
-                    <a href="#neighbournebula" data-toggle="tab">Neighbour Nebula</a>
-                </li>
             </ul>
             <!-- RIGHT NAV -->
             <ul class="nav navbar-nav navbar-right">
@@ -48,177 +45,157 @@
     </nav>
     <!-- PAGE CONTENT -->
     <div class="container">
-    <div id="tabContent" class="tab-content">
-        <!-- SCREEN SUMMARY -->
-        <div class="tab-pane fade" id="home">
-        </div>
-        <div class="tab-pane fade" id="summary">
-            <p>
-                <span class="header">Name: </span>
-                <span id="name">Loading ...</span>
-            </p>
-            <p>
-                <span class="header">Description: </span>
-                <span id="desc">Loading ...</span>
-            </p>
-            <p>
-                <span class="header">Samples: </span>
-                <span id="samples">Loading ...</span>
-            </p>
-        </div>
-        <!-- NEIGHBOUR NEBULA -->
-        <div class="tab-pane fade" id="neighbournebula">
-            <div class="row">
-                <div class="col-lg-7">
-                    <div class="row plotbox" id="neighbourplot"></div>
+        <div class="row">
+            <div class="col-lg-7">
+                <div class="row plotbox" id="neighbourplot"></div>
+            </div>
+            <div class="col-lg-5 gallery">
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered selected-image-display">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-0" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
                 </div>
-                <div class="col-lg-5 gallery">
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered selected-image-display">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-0" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                <div class="row-centered">
+                    <div class="col-lg-12 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-1" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-12 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-1" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-2" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-3" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-2" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-4" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-5" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-6" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-3" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-7" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-8" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-9" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-4" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-10" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-11" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-12" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-5" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-13" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-14" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-15" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-6" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-16" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-17" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-18" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-7" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-19" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-20" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-21" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-8" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
-                    <div class="row-centered">
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-22" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-23" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
-                        <div class="col-lg-3 col-centered thumb">
-                            <a class="thumbnail" href="#">
-                                <img id="nebula-24" class="img-responsive" src="" alt="">
-                            </a>
-                        </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-9" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-10" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-11" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-12" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-13" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-14" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-15" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-16" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-17" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-18" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-19" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-20" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-21" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                </div>
+                <div class="row-centered">
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-22" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-23" class="img-responsive" src="" alt="">
+                        </a>
+                    </div>
+                    <div class="col-lg-3 col-centered thumb">
+                        <a class="thumbnail" href="#">
+                            <img id="nebula-24" class="img-responsive" src="" alt="">
+                        </a>
                     </div>
                 </div>
             </div>
-            <div class="row">
+        </div>
+        <div class="row">
                 <div class="col-lg-6">
                     <div class="row plotbox" id="lineplot">
                     </div>
@@ -228,9 +205,7 @@
                     </div>
                 </div>
             </div>
-        </div>
     </div>
-</div>
 </div>
 <!-- SIDEBAR CONTENT -->
 <!-- See http://plugins.adchsm.me/slidebars/ for additional info -->

--- a/public/index.html
+++ b/public/index.html
@@ -41,9 +41,6 @@
                 <li class="navbar-item hidden">
                     <a href="#neighbournebula" data-toggle="tab">Neighbour Nebula</a>
                 </li>
-                <li class="navbar-item hidden">
-                    <a href="#clusterplot" data-toggle="tab">Cluster Cosmologist</a>
-                </li>
             </ul>
             <!-- RIGHT NAV -->
             <ul class="nav navbar-nav navbar-right">
@@ -237,20 +234,6 @@
                                 <img id="nebula-24" class="img-responsive" src="" alt="">
                             </a>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- CLUSTER COSMOLOGIST -->
-        <div class="tab-pane fade" id ="clusterplot">
-            <div class="row">
-                <div class="col-lg-3 plotbox">
-                    <label for="cluster-slider">Number Clusters:</label>
-                    <input id="cluster-slider" type="range" step="1"/>
-                    <span id="cluster-number">2</span>
-                </div>
-                <div class="col-lg-9 plotbox">
-                    <div class="row plotbox" id="clusterpcaplot">
                     </div>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -33,12 +33,6 @@
                     </ul>
                 </li>
                 <li class="navbar-item hidden">
-                    <a href="#summary" data-toggle="tab">Screen Summary</a>
-                </li>
-                <li class="navbar-item hidden">
-                    <a href="#featurexplorer" data-toggle="tab">Feature Explorer</a>
-                </li>
-                <li class="navbar-item hidden">
                     <a href="#neighbournebula" data-toggle="tab">Neighbour Nebula</a>
                 </li>
             </ul>
@@ -71,19 +65,6 @@
                 <span class="header">Samples: </span>
                 <span id="samples">Loading ...</span>
             </p>
-        </div>
-        <!-- FEATURE EXPLORER -->
-        <div class="tab-pane fade" id="featurexplorer">
-            <div class="row">
-                <div class="col-md-6 plotbox" id="linecol">
-                    <div class="row plotbox" id="lineplot">
-                    </div>
-                </div>
-                <div class="col-md-6 plotbox">
-                    <div class="row plotbox" id="histplot">
-                    </div>
-                </div>
-            </div>
         </div>
         <!-- NEIGHBOUR NEBULA -->
         <div class="tab-pane fade" id="neighbournebula">
@@ -234,6 +215,16 @@
                                 <img id="nebula-24" class="img-responsive" src="" alt="">
                             </a>
                         </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-6">
+                    <div class="row plotbox" id="lineplot">
+                    </div>
+                </div>
+                <div class="col-lg-6">
+                    <div class="row plotbox" id="histplot">
                     </div>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -45,11 +45,23 @@
     </nav>
     <!-- PAGE CONTENT -->
     <div class="container">
-        <div class="row">
-            <div class="col-lg-7">
+        <div class="col-lg-8">
+            <div class="row">
                 <div class="row plotbox" id="neighbourplot"></div>
             </div>
-            <div class="col-lg-5 gallery">
+            <div class="row">
+                <div class="col-lg-6">
+                    <div class="row plotbox" id="lineplot">
+                    </div>
+                </div>
+                <div class="col-lg-6">
+                    <div class="row plotbox" id="histplot">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-4">
+            <div class="col-lg-12 gallery">
                 <div class="row-centered">
                     <div class="col-lg-3 col-centered selected-image-display">
                         <a class="thumbnail" href="#">
@@ -195,16 +207,6 @@
                 </div>
             </div>
         </div>
-        <div class="row">
-                <div class="col-lg-6">
-                    <div class="row plotbox" id="lineplot">
-                    </div>
-                </div>
-                <div class="col-lg-6">
-                    <div class="row plotbox" id="histplot">
-                    </div>
-                </div>
-            </div>
     </div>
 </div>
 <!-- SIDEBAR CONTENT -->

--- a/public/js/Filter.js
+++ b/public/js/Filter.js
@@ -19,6 +19,8 @@ var $filterForm = $('#filter-form');
 var $filterAdd = $('#filter-add');
 var $filterRemove = $('#filter-remove');
 
+var ENTER = 13;
+
 
 /**
  * SampleFilter: Setup sample filter.
@@ -147,7 +149,7 @@ SampleFilter.prototype.mountEventListeners = function() {
     // using $(parent).on(event, element, function) as events must be bound to
     // elements that may not exist at time of page rendering
     $filterMenu.on('keydown dblclick', '#gene-select', function(event) {
-        if(event.which === 13 || event.type === 'dblclick') {
+        if(event.which === ENTER || event.type === 'dblclick') {
             event.preventDefault();
             self.addToFilter();
         }
@@ -155,7 +157,7 @@ SampleFilter.prototype.mountEventListeners = function() {
 
     // attach enter key and double listener to selected box
     $filterMenu.on('keydown dblclick', '#gene-selected', function(event) {
-        if(event.which === 13 || event.type === 'dblclick') {
+        if(event.which === ENTER || event.type === 'dblclick') {
             event.preventDefault();
             self.removeFromFilter();
         }
@@ -171,7 +173,7 @@ SampleFilter.prototype.mountEventListeners = function() {
 
     // update selected gene when enter pressed on textbox
     $geneFilterText.on('keypress', function(event) {
-        if(event.which === 13) {
+        if(event.which === ENTER) {
             self.addToFilter();
         }
     });

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -15,10 +15,11 @@ function Histogram(sampleData, element, featureNames) {
     this.sampleData = sampleData;
     this.featureNames = featureNames;
     this.feature = 0;
-
     this.element = element;
-    this.fullWidth = 420;
-    this.fullHeight = 225;
+
+    this.fullWidth = $(this.element).width();
+    this.fullHeight = Math.round(this.fullWidth * (9/16));
+
     this.xAxisTicks = 8;
     this.yAxisTicks = 5;
 

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -17,7 +17,7 @@ function Histogram(sampleData, element, featureNames) {
     this.feature = 0;
 
     this.element = element;
-    this.fullWidth = 400;
+    this.fullWidth = 420;
     this.fullHeight = 225;
     this.xAxisTicks = 8;
     this.yAxisTicks = 5;

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -17,12 +17,12 @@ function Histogram(sampleData, element, featureNames) {
     this.feature = 0;
 
     this.element = element;
-    this.fullWidth = 500;
-    this.fullHeight = 200;
+    this.fullWidth = 400;
+    this.fullHeight = 225;
     this.xAxisTicks = 8;
     this.yAxisTicks = 5;
 
-    this.margin = {top: 20, right: 30, bottom: 20, left: 45};
+    this.margin = {top: 20, right: 40, bottom: 30, left: 40};
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -16,6 +16,8 @@ _.mixin(require('lodash-deep'));
  * @param {array} featureNames - An array of the features used in this screen.
  */
 function Histogram(sampleData, element, featureNames) {
+    var self = this;
+
     this.sampleData = sampleData;
     this.featureNames = featureNames;
     this.feature = 0;
@@ -31,7 +33,11 @@ function Histogram(sampleData, element, featureNames) {
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 
-    this.drawHistogram(0);
+    $('body').on('linePlotUpdate', function(event, activeFeature) {
+        self.drawHistogram(activeFeature-1);
+    });
+
+    self.drawHistogram(0);
 }
 
 /**

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -18,7 +18,7 @@ function Histogram(sampleData, element, featureNames) {
 
     this.element = element;
     this.fullWidth = 500;
-    this.fullHeight = 400;
+    this.fullHeight = 200;
     this.xAxisTicks = 8;
     this.yAxisTicks = 5;
 

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -23,7 +23,7 @@ function Histogram(sampleData, element, featureNames) {
     this.xAxisTicks = 8;
     this.yAxisTicks = 5;
 
-    this.margin = {top: 20, right: 40, bottom: 30, left: 40};
+    this.margin = {top: 20, right: 30, bottom: 30, left: 50};
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 

--- a/public/js/Histogram.js
+++ b/public/js/Histogram.js
@@ -5,6 +5,10 @@ _.mixin(require('lodash-deep'));
 /**
  * Histogram: Object to draw a histogram of the features across a dataset.
  *
+ * The width and height of the plot is calculated based on the size of the
+ * plot's containing DIV. The width is taken from the DIV, and the height
+ * calculated from that width such that the plot will have a 16:9 aspect ratio.
+ *
  * @constructor
  * @param {array} sampleData - The sample data for the screen. Each element
  *     in the array is an instance of a Sample document.

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -8,6 +8,10 @@ var _ = require('lodash');
  * lineplot triggers an update in a Histogram object showing the distribution
  * of the corresponding feature.
  *
+ * The width and height of the plot is calculated based on the size of the
+ * plot's containing DIV. The width is taken from the DIV, and the height
+ * calculated from that width such that the plot will have a 16:9 aspect ratio.
+ *
  * @constructor
  * @param {array} sampleData - The sample data for the screen. Each element
  *     in the array is an instance of a Sample document.
@@ -20,7 +24,6 @@ function Lineplot(sampleData, element, histogram) {
 
     this.sampleData = sampleData;
     this.featureLength = sampleData[0].feature_vector_std.length;
-    this.activeSample = 0;
     this.activeFeature = 0;
     this.histogram = histogram;
     this.element = element;

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -24,11 +24,11 @@ function Lineplot(sampleData, element, histogram) {
 
     this.element = element;
     this.fullWidth = 400;
-    this.fullHeight = 150;
+    this.fullHeight = 225;
     this.xAxisTicks = 10;
     this.yAxisTicks = 5;
 
-    this.margin = {top: 20, right: 30, bottom: 20, left: 45};
+    this.margin = {top: 20, right: 40, bottom: 30, left: 40};
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 }

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -23,9 +23,9 @@ function Lineplot(sampleData, element, histogram) {
     this.histogram = histogram;
 
     this.element = element;
-    this.fullWidth = 400;
+    this.fullWidth = 420;
     this.fullHeight = 225;
-    this.xAxisTicks = 10;
+    this.xAxisTicks = 8;
     this.yAxisTicks = 5;
 
     this.margin = {top: 20, right: 40, bottom: 30, left: 40};

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -16,6 +16,8 @@ var _ = require('lodash');
  *     a part of the Lineplot is clicked.
  */
 function Lineplot(sampleData, element, histogram) {
+    var self = this;
+
     this.sampleData = sampleData;
     this.featureLength = sampleData[0].feature_vector_std.length;
     this.activeSample = 0;
@@ -32,6 +34,10 @@ function Lineplot(sampleData, element, histogram) {
     this.margin = {top: 20, right: 40, bottom: 30, left: 40};
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
+
+    $('body').on('redrawLineplot', function(event, sampleId) {
+        self.drawLineplot(sampleId);
+    });
 }
 
 /**

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -1,6 +1,9 @@
 var d3 = require('d3');
 var _ = require('lodash');
 
+var LEFTARROW = 37;
+var RIGHTARROW = 39;
+
 /**
  * Lineplot: Object to draw lineplot of sample feature distribution.
  *
@@ -211,11 +214,11 @@ Lineplot.prototype.keypressUpdate = function(keyCode) {
     var self = this;
 
     if(self.activeFeature) {
-        if(keyCode === 39 && self.activeFeature < this.featureLength) {
+        if(keyCode === RIGHTARROW && self.activeFeature < this.featureLength) {
             self.activeFeature++;
             $('body').trigger('linePlotUpdate', self.activeFeature);
         }
-        else if(keyCode === 37 && self.activeFeature > 1) {
+        else if(keyCode === LEFTARROW && self.activeFeature > 1) {
             self.activeFeature--;
             $('body').trigger('linePlotUpdate', self.activeFeature);
         }

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -21,10 +21,11 @@ function Lineplot(sampleData, element, histogram) {
     this.activeSample = 0;
     this.activeFeature = 0;
     this.histogram = histogram;
-
     this.element = element;
-    this.fullWidth = 420;
-    this.fullHeight = 225;
+
+    this.fullWidth = $(this.element).width();
+    this.fullHeight = Math.round(this.fullWidth * (9/16));
+
     this.xAxisTicks = 8;
     this.yAxisTicks = 5;
 

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -36,6 +36,8 @@ function Lineplot(sampleData, element) {
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 
+    $body.unbind('redrawLineplot');
+
     $body.on('redrawLineplot', function(event, sampleId) {
         self.drawLineplot(sampleId);
     });

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -16,16 +16,14 @@ var _ = require('lodash');
  * @param {array} sampleData - The sample data for the screen. Each element
  *     in the array is an instance of a Sample document.
  * @param {string} element - The ID of the target div for this plot.
- * @param {Histogram} histogram - Histogram plot object that will update when
- *     a part of the Lineplot is clicked.
  */
-function Lineplot(sampleData, element, histogram) {
+function Lineplot(sampleData, element) {
     var self = this;
+    var $body = $('body');
 
     this.sampleData = sampleData;
     this.featureLength = sampleData[0].feature_vector_std.length;
     this.activeFeature = 0;
-    this.histogram = histogram;
     this.element = element;
 
     this.fullWidth = $(this.element).width();
@@ -38,8 +36,12 @@ function Lineplot(sampleData, element, histogram) {
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 
-    $('body').on('redrawLineplot', function(event, sampleId) {
+    $body.on('redrawLineplot', function(event, sampleId) {
         self.drawLineplot(sampleId);
+    });
+
+    $body.on('linePlotUpdate', function(event, activeFeature) {
+      self.updateActiveLine(activeFeature);
     });
 }
 
@@ -188,8 +190,7 @@ Lineplot.prototype.onClickUpdate = function (d3Mouse) {
 
     if(clickedFeature <= self.featureLength && clickedFeature > 1) {
         self.activeFeature = clickedFeature;
-        self.histogram.drawHistogram(self.activeFeature-1);
-        self.updateActiveLine(self.activeFeature);
+        $('body').trigger('linePlotUpdate', self.activeFeature);
     }
 };
 
@@ -209,14 +210,12 @@ Lineplot.prototype.keypressUpdate = function(keyCode) {
 
     if(self.activeFeature) {
         if(keyCode === 39 && self.activeFeature < this.featureLength) {
-            this.activeFeature++;
-            self.histogram.drawHistogram(self.activeFeature-1);
-            self.updateActiveLine(self.activeFeature);
+            self.activeFeature++;
+            $('body').trigger('linePlotUpdate', self.activeFeature);
         }
         else if(keyCode === 37 && self.activeFeature > 1) {
-            this.activeFeature--;
-            self.histogram.drawHistogram(self.activeFeature-1);
-            self.updateActiveLine(self.activeFeature);
+            self.activeFeature--;
+            $('body').trigger('linePlotUpdate', self.activeFeature);
         }
     }
 };

--- a/public/js/Lineplot.js
+++ b/public/js/Lineplot.js
@@ -23,8 +23,8 @@ function Lineplot(sampleData, element, histogram) {
     this.histogram = histogram;
 
     this.element = element;
-    this.fullWidth = 600;
-    this.fullHeight = 400;
+    this.fullWidth = 400;
+    this.fullHeight = 150;
     this.xAxisTicks = 10;
     this.yAxisTicks = 5;
 

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -80,8 +80,13 @@ NeighbourImages.prototype.getImages = function(query_id) {
 NeighbourImages.prototype.setImages = function() {
     var self = this;
 
-    $('#nebula-0').attr('src', 'data:image/jpg;base64,' + self.selectedImage.image_full);
-    $('#nebula-0').attr('title', self.selectedImage.sample_id);
+    $('#nebula-0')
+        .attr('src', 'data:image/jpg;base64,' + self.selectedImage.image_full)
+        .attr('title', self.selectedImage.sample_id)
+        .on('click', function(event) {
+            // prevent browser from scrolling to top when main image clicked on
+            event.preventDefault();
+        });
 
     for(var i = 0; i < self.neighbourImages.length; i++) {
         var $nebulaSelector = $('#nebula-' + (i+1));
@@ -90,7 +95,8 @@ NeighbourImages.prototype.setImages = function() {
             .attr('title', self.neighbourImages[i].sample_id);
         $nebulaSelector.unbind('click');
         (function(j) {
-            $nebulaSelector.on('click', function() {
+            $nebulaSelector.on('click', function(event) {
+                event.preventDefault();
                 $('body').trigger('updatePoint', [self.neighbours[j]])
             });
         })(i);

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -94,7 +94,7 @@ NeighbourImages.prototype.setImages = function() {
     if(self.selectedImage) {
         $nebula0
             .attr('src', 'data:image/jpg;base64,' +
-                self.selectedImage.image_full)
+                self.selectedImage.image_large)
             .attr('title', self.selectedImage.sample_id)
     }
 

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -7,6 +7,20 @@ function NeighbourImages() {
     this.neighbours = [];
     this.selectedImage = "";
     this.neighbourImages = [];
+
+    var divWidth = Math.round($('#image-column').width()) - 20;
+    var imgWidth = Math.round(divWidth/3) - 20;
+
+    // set size of fullsize image
+    $('.selected-image-display')
+        .css('width', divWidth)
+        .css('height', divWidth);
+
+    // set size of thumbnail size image
+    $('.thumb')
+        .css('width', imgWidth)
+        .css('height', imgWidth)
+
 }
 
 /**
@@ -18,6 +32,11 @@ function NeighbourImages() {
  */
 NeighbourImages.prototype.getImages = function(query_id) {
     var self = this;
+
+    var height = Math.round($('#plot-column').height() - 10);
+    $('#image-column')
+        .css('height', height);
+
 
     $.when(
         $.ajax({

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -1,9 +1,13 @@
+var _ = require('lodash');
+
 /**
  * NeighbourImages: Object to get and set images in the gallery.
  *
  * @constructor
  */
 function NeighbourImages() {
+    var self = this;
+
     this.neighbours = [];
     this.selectedImage = "";
     this.neighbourImages = [];
@@ -19,7 +23,11 @@ function NeighbourImages() {
     // set size of thumbnail size image
     $('.thumb')
         .css('width', imgWidth)
-        .css('height', imgWidth)
+        .css('height', imgWidth);
+
+    $('body').on('updatePoint', function(event, d) {
+        self.getImages(d._id);
+    });
 
 }
 
@@ -41,28 +49,22 @@ NeighbourImages.prototype.getImages = function(query_id) {
     $.when(
         $.ajax({
             url: '/api/sample/neighbours/' + query_id,
-            async: false,
             success: function(json) {
-                var neighboursLength = json[0].length;
-                self.neighbours = json[0].neighbours.slice(1,
-                    neighboursLength);
+                json.shift(); // don't need first document
+                self.neighbours = json;
             }
         }),
         $.ajax({
             url: '/api/image/' + query_id,
-            async: false,
             success: function(json) {
                 self.selectedImage = json[0];
             }
         }),
         $.ajax({
             type: 'GET',
-            url: '/api/images/',
-            data: {
-                'sample_ids': self.neighbours
-            },
-            async: false,
+            url: '/api/images/' + query_id,
             success: function(json) {
+                json.shift(); // don't need first document
                 self.neighbourImages = json;
             }
         })).then(function(res, status) {
@@ -82,10 +84,21 @@ NeighbourImages.prototype.setImages = function() {
     $('#nebula-0').attr('title', self.selectedImage.sample_id);
 
     for(var i = 0; i < self.neighbourImages.length; i++) {
-        var nebula_selector = '#nebula-' + (i+1);
-        $(nebula_selector).attr('src', 'data:image/jpg;base64,' + self.neighbourImages[i].image_thumb);
-        $(nebula_selector).attr('title', self.neighbourImages[i].sample_id);
+        var $nebulaSelector = $('#nebula-' + (i+1));
+        $nebulaSelector
+            .attr('src', 'data:image/jpg;base64,' + self.neighbourImages[i].image_thumb)
+            .attr('title', self.neighbourImages[i].sample_id);
+        $nebulaSelector.unbind('click');
+        (function(j) {
+            $nebulaSelector.on('click', function() {
+                $('body').trigger('updatePoint', [self.neighbours[j]])
+            });
+        })(i);
     }
 };
+
+function foo(j) {
+    console.log(s)
+}
 
 module.exports = NeighbourImages;

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -17,13 +17,11 @@ function NeighbourImages() {
 
     // set size of fullsize image
     $('.selected-image-display')
-        .css('width', divWidth)
-        .css('height', divWidth);
+        .css('width', divWidth);
 
     // set size of thumbnail size image
     $('.thumb')
-        .css('width', imgWidth)
-        .css('height', imgWidth);
+        .css('width', imgWidth);
 
     $('body').on('updatePoint', function(event, d) {
         self.getImages(d._id);

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -79,32 +79,48 @@ NeighbourImages.prototype.getImages = function(query_id) {
  */
 NeighbourImages.prototype.setImages = function() {
     var self = this;
+    var $nebula0 = $('#nebula-0');
 
-    $('#nebula-0')
-        .attr('src', 'data:image/jpg;base64,' + self.selectedImage.image_full)
-        .attr('title', self.selectedImage.sample_id)
-        .on('click', function(event) {
-            // prevent browser from scrolling to top when main image clicked on
-            event.preventDefault();
-        });
+    // make all img frames empty
+    $nebula0
+        .attr('src', '//:0')
+        .attr('title', 'not found');
 
+    $('.thumbnail > img')
+        .attr('src', '//:0')
+        .attr('title', 'not found');
+
+    // add selected main image, if it exists
+    if(self.selectedImage) {
+        $nebula0
+            .attr('src', 'data:image/jpg;base64,' +
+                self.selectedImage.image_full)
+            .attr('title', self.selectedImage.sample_id)
+    }
+
+    $nebula0.on('click', function(event) {
+        // prevent browser from scrolling to top when main image clicked on
+        event.preventDefault();
+    });
+
+
+    // iterate through all found images and add them to the gallery
     for(var i = 0; i < self.neighbourImages.length; i++) {
         var $nebulaSelector = $('#nebula-' + (i+1));
         $nebulaSelector
-            .attr('src', 'data:image/jpg;base64,' + self.neighbourImages[i].image_thumb)
+            .attr('src', 'data:image/jpg;base64,' +
+                self.neighbourImages[i].image_thumb)
             .attr('title', self.neighbourImages[i].sample_id);
         $nebulaSelector.unbind('click');
         (function(j) {
             $nebulaSelector.on('click', function(event) {
+                // prevent browser from scrolling to top when main image
+                // clicked and trigger event to update the plot
                 event.preventDefault();
                 $('body').trigger('updatePoint', [self.neighbours[j]])
             });
         })(i);
     }
 };
-
-function foo(j) {
-    console.log(s)
-}
 
 module.exports = NeighbourImages;

--- a/public/js/NeighbourImages.js
+++ b/public/js/NeighbourImages.js
@@ -36,9 +36,9 @@ function NeighbourImages() {
  * neighbour images.
  *
  * @this {NeighbourImages}
- * @params {string} - _id of the query sample
+ * @params {string} sample_id - The _id of the query sample
  */
-NeighbourImages.prototype.getImages = function(query_id) {
+NeighbourImages.prototype.getImages = function(sample_id) {
     var self = this;
 
     var height = Math.round($('#plot-column').height() - 10);
@@ -48,21 +48,21 @@ NeighbourImages.prototype.getImages = function(query_id) {
 
     $.when(
         $.ajax({
-            url: '/api/sample/neighbours/' + query_id,
+            url: '/api/sample/neighbours/' + sample_id,
             success: function(json) {
                 json.shift(); // don't need first document
                 self.neighbours = json;
             }
         }),
         $.ajax({
-            url: '/api/image/' + query_id,
+            url: '/api/image/' + sample_id,
             success: function(json) {
                 self.selectedImage = json[0];
             }
         }),
         $.ajax({
             type: 'GET',
-            url: '/api/images/' + query_id,
+            url: '/api/images/' + sample_id,
             success: function(json) {
                 json.shift(); // don't need first document
                 self.neighbourImages = json;
@@ -74,6 +74,9 @@ NeighbourImages.prototype.getImages = function(query_id) {
 
 /**
  * setImages: Convert base64 encoded strings to images and set them in the DOM.
+ *
+ * Clicking on 'neighbour' images sets the corresponding point in the PCA plot as the
+ * active point.
  *
  * @this {NeighbourImages}
  */
@@ -95,7 +98,7 @@ NeighbourImages.prototype.setImages = function() {
         $nebula0
             .attr('src', 'data:image/jpg;base64,' +
                 self.selectedImage.image_large)
-            .attr('title', self.selectedImage.sample_id)
+            .attr('title', self.selectedImage.sample_id);
     }
 
     $nebula0.on('click', function(event) {
@@ -117,7 +120,7 @@ NeighbourImages.prototype.setImages = function() {
                 // prevent browser from scrolling to top when main image
                 // clicked and trigger event to update the plot
                 event.preventDefault();
-                $('body').trigger('updatePoint', [self.neighbours[j]])
+                $('body').trigger('updatePoint', [self.neighbours[j]]);
             });
         })(i);
     }

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -73,10 +73,10 @@ NeighbourPlot.prototype.drawScatterplot = function() {
 
     this.destroy();
 
-    var xMin = d3.min(this.sampleData, function(d) { return d.pca[0]; });
-    var yMin = d3.min(this.sampleData, function(d) { return d.pca[1]; });
-    var xMax = d3.max(this.sampleData, function(d) { return d.pca[0]; });
-    var yMax = d3.max(this.sampleData, function(d) { return d.pca[1]; });
+    var xMin = d3.min(this.sampleData, function(d) { return d.pca_vector[0]; });
+    var yMin = d3.min(this.sampleData, function(d) { return d.pca_vector[1]; });
+    var xMax = d3.max(this.sampleData, function(d) { return d.pca_vector[0]; });
+    var yMax = d3.max(this.sampleData, function(d) { return d.pca_vector[1]; });
 
     // setup scales and axis
     self.xScale = d3.scale.linear()
@@ -142,10 +142,10 @@ NeighbourPlot.prototype.drawScatterplot = function() {
         .enter()
         .append('circle')
         .attr('cx', function(d) {
-            return self.xScale(d.pca[0]);
+            return self.xScale(d.pca_vector[0]);
         })
         .attr('cy', function(d) {
-            return self.yScale(d.pca[1]);
+            return self.yScale(d.pca_vector[1]);
         })
         .attr('r', 5)
         .classed('scatterpt', true)

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -69,6 +69,7 @@ function NeighbourPlot(sampleData, element) {
  */
 NeighbourPlot.prototype.drawScatterplot = function() {
     var self = this;
+    var $body = $('body');
 
     this.destroy();
 
@@ -158,14 +159,14 @@ NeighbourPlot.prototype.drawScatterplot = function() {
         .on('click', function(d) {
             var selection = d3.select(this);
             if(!selection.classed('activept')) {
-                $('body').trigger('updatePoint', d);
-                $('body').trigger('updateGallery', d._id);
+                $body.trigger('updatePoint', d);
+                $body.trigger('updateGallery', d._id);
             }
         });
 
     // default select first point
-    $('body').trigger('updatePoint', this.sampleData[0]);
-    $('body').trigger('updateGallery', this.sampleData[0]._id);
+    $body.trigger('updatePoint', this.sampleData[0]);
+    $body.trigger('updateGallery', this.sampleData[0]._id);
 };
 
 /**
@@ -185,14 +186,14 @@ NeighbourPlot.prototype.updatePoint = function(d) {
 
     $('body').trigger('redrawLineplot', [d._id]);
 
-    d3.selectAll('.activept')
+    self.svg.selectAll('.activept')
         .classed('activept', false)
         .classed('neighbourpt', false)
         .transition()
         .duration(self.transitionDuration)
         .attr('r', self.inactivePointRadius);
 
-    d3.selectAll('.neighbourpt')
+    self.svg.selectAll('.neighbourpt')
         .classed('neighbourpt', false)
         .attr('r', self.inactivePointRadius)
         .transition()
@@ -214,6 +215,7 @@ NeighbourPlot.prototype.updatePoint = function(d) {
     // set class and attr of new active point
     d3.select('#' + d._id)
         .classed('activept', true)
+        .moveToFront()
         .transition()
         .duration(self.transitionDuration)
         .attr('r', self.activePointRadius);

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -27,11 +27,14 @@ d3.selection.prototype.moveToFront = function() {
  * Clicking on scatterplot points will trigger updates of the neighbour
  * image gallery and corresponding sample lineplot.
  *
+ * The width and height of the plot is calculated based on the size of the
+ * plot's containing DIV. The width is taken from the DIV, and the height
+ * calculated from that width such that the plot will have a 16:9 aspect ratio.
+ *
  * @constructor
  * @param {array} sampleData - The sample data for the screen. Each element
  *     in the array is an instance of a Sample document.
  * @param {string} element - The ID of the target div for this plot.
- * @param {NeighbourImages} neighbourImages - NeighbourImages object that will
  * update when scatterplot points are clicked.
  */
 function NeighbourPlot(sampleData, element) {
@@ -54,7 +57,7 @@ function NeighbourPlot(sampleData, element) {
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 
     $('body').on('updatePoint', function(event, d) {
-        self.updatePoint(d)
+        self.updatePoint(d);
     });
 
     this.drawScatterplot();
@@ -177,8 +180,6 @@ NeighbourPlot.prototype.drawScatterplot = function() {
  * lineplot and neighbour image gallery.
  *
  * @this {NeighbourPlot}
- * @param {d3-selection} selection - The d3 selection object from the
- *     clicked scatterplot point.
  * @param {object} d - The datum attached to the clicked scatterplot point.
  */
 NeighbourPlot.prototype.updatePoint = function(d) {
@@ -224,7 +225,8 @@ NeighbourPlot.prototype.updatePoint = function(d) {
 /**
  * updatePlot: Re-render plot data points given a new set of data.
  *
- * Uses D3 enter-update-select pattern to update the plot datapoints.
+ * Update the class of scatterplot points, and bring unfiltered points
+ * to the top of the SVG stack.
  *
  * @this {NeighbourPlot}
  * @param {array} newData - The new dataset to display.
@@ -235,7 +237,7 @@ NeighbourPlot.prototype.updatePlot = function(newData) {
     if(newData.length === this.sampleData.length) {
         // if no points have been filtered out, class everything as unfiltered
         self.svg.selectAll('circle')
-            .classed('filtered', false)
+            .classed('filtered', false);
     }
     else {
         // cast sample ids as id #tags so they can be used as selectors

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -42,8 +42,8 @@ function NeighbourPlot(sampleData, element, lineplot, neighbourImages) {
     this.neighbourImages = neighbourImages;
 
     this.element = element;
-    this.fullWidth = 500;
-    this.fullHeight = 300;
+    this.fullWidth = 800;
+    this.fullHeight = 450;
     this.transitionDuration = 125;
     this.inactivePointRadius = 5;
     this.activePointRadius = 7;

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -42,8 +42,8 @@ function NeighbourPlot(sampleData, element, lineplot, neighbourImages) {
     this.neighbourImages = neighbourImages;
 
     this.element = element;
-    this.fullWidth = 700;
-    this.fullHeight = 500;
+    this.fullWidth = 500;
+    this.fullHeight = 300;
     this.transitionDuration = 125;
     this.inactivePointRadius = 5;
     this.activePointRadius = 7;

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -34,11 +34,10 @@ d3.selection.prototype.moveToFront = function() {
  * @param {NeighbourImages} neighbourImages - NeighbourImages object that will
  * update when scatterplot points are clicked.
  */
-function NeighbourPlot(sampleData, element, neighbourImages) {
+function NeighbourPlot(sampleData, element) {
     var self = this;
 
     this.sampleData = sampleData;
-    this.neighbourImages = neighbourImages;
     this.element = element;
 
     this.fullWidth = $(this.element).width();
@@ -54,8 +53,8 @@ function NeighbourPlot(sampleData, element, neighbourImages) {
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
 
-    $('body').on('updatePoint', function(event, selection, d) {
-        self.updatePoint(selection, d)
+    $('body').on('updatePoint', function(event, d) {
+        self.updatePoint(d)
     });
 
     this.drawScatterplot();
@@ -159,12 +158,14 @@ NeighbourPlot.prototype.drawScatterplot = function() {
         .on('click', function(d) {
             var selection = d3.select(this);
             if(!selection.classed('activept')) {
-                $('body').trigger('updatePoint', [d]);
+                $('body').trigger('updatePoint', d);
+                $('body').trigger('updateGallery', d._id);
             }
         });
 
     // default select first point
-    self.updatePoint(this.sampleData[0])
+    $('body').trigger('updatePoint', this.sampleData[0]);
+    $('body').trigger('updateGallery', this.sampleData[0]._id);
 };
 
 /**
@@ -182,7 +183,6 @@ NeighbourPlot.prototype.drawScatterplot = function() {
 NeighbourPlot.prototype.updatePoint = function(d) {
     var self = this;
 
-    self.neighbourImages.getImages(d._id);
     $('body').trigger('redrawLineplot', [d._id]);
 
     d3.selectAll('.activept')

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -31,14 +31,13 @@ d3.selection.prototype.moveToFront = function() {
  * @param {array} sampleData - The sample data for the screen. Each element
  *     in the array is an instance of a Sample document.
  * @param {string} element - The ID of the target div for this plot.
- * @param {LinePlot} lineplot - LinePlot that will update when scatterplot
- *     points are clicked.
  * @param {NeighbourImages} neighbourImages - NeighbourImages object that will
  * update when scatterplot points are clicked.
  */
-function NeighbourPlot(sampleData, element, lineplot, neighbourImages) {
+function NeighbourPlot(sampleData, element, neighbourImages) {
+    var self = this;
+
     this.sampleData = sampleData;
-    this.lineplot = lineplot;
     this.neighbourImages = neighbourImages;
     this.element = element;
 
@@ -54,6 +53,10 @@ function NeighbourPlot(sampleData, element, lineplot, neighbourImages) {
     this.margin = {top: 10, right: 40, bottom: 30, left: 40};
     this.width = this.fullWidth - this.margin.left - this.margin.right;
     this.height = this.fullHeight - this.margin.top - this.margin.bottom;
+
+    $('body').on('updatePoint', function(event, selection, d) {
+        self.updatePoint(selection, d)
+    });
 
     this.drawScatterplot();
 }
@@ -156,13 +159,12 @@ NeighbourPlot.prototype.drawScatterplot = function() {
         .on('click', function(d) {
             var selection = d3.select(this);
             if(!selection.classed('activept')) {
-                self.updatePoint(selection, d);
+                $('body').trigger('updatePoint', [d]);
             }
         });
 
     // default select first point
-    var first = d3.select('.scatterpt');
-    self.updatePoint(first, this.sampleData[0])
+    self.updatePoint(this.sampleData[0])
 };
 
 /**
@@ -177,11 +179,11 @@ NeighbourPlot.prototype.drawScatterplot = function() {
  *     clicked scatterplot point.
  * @param {object} d - The datum attached to the clicked scatterplot point.
  */
-NeighbourPlot.prototype.updatePoint = function(selection, d) {
+NeighbourPlot.prototype.updatePoint = function(d) {
     var self = this;
 
     self.neighbourImages.getImages(d._id);
-    self.lineplot.drawLineplot(d._id);
+    $('body').trigger('redrawLineplot', [d._id]);
 
     d3.selectAll('.activept')
         .classed('activept', false)
@@ -210,7 +212,7 @@ NeighbourPlot.prototype.updatePoint = function(selection, d) {
     }
 
     // set class and attr of new active point
-    selection
+    d3.select('#' + d._id)
         .classed('activept', true)
         .transition()
         .duration(self.transitionDuration)

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -40,10 +40,11 @@ function NeighbourPlot(sampleData, element, lineplot, neighbourImages) {
     this.sampleData = sampleData;
     this.lineplot = lineplot;
     this.neighbourImages = neighbourImages;
-
     this.element = element;
-    this.fullWidth = 800;
-    this.fullHeight = 450;
+
+    this.fullWidth = $(this.element).width();
+    this.fullHeight = Math.round(this.fullWidth * (9/16));
+
     this.transitionDuration = 125;
     this.inactivePointRadius = 5;
     this.activePointRadius = 7;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -35,7 +35,6 @@ function updateSelector(screen_data) {
     }
 }
 
-// FIXME does not corectly switch between screens
 function selectScreen(screen_id) {
     var featureNames = [];
     var sampleData = [];

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -35,6 +35,7 @@ function updateSelector(screen_data) {
     }
 }
 
+// FIXME does not corectly switch between screens
 function selectScreen(screen_id) {
     var featureNames = [];
     var sampleData = [];
@@ -79,6 +80,6 @@ function mountPlots(screenData, sampleData, featureNames) {
     var neighbourImages = new NeighbourImages(sampleData[0]._id);
     var histogram = new Histogram(sampleData, '#histplot' ,featureNames);
     var lineplot = new Lineplot(sampleData, '#lineplot', histogram);
-    var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot', lineplot, neighbourImages);
+    var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot', neighbourImages);
     var filter = new Filter(sampleData, neighbourPlot);
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3,7 +3,6 @@ var Histogram = require('./Histogram.js');
 var Lineplot = require('./Lineplot.js');
 var NeighbourPlot = require('./NeighbourPlot.js');
 var NeighbourImages = require('./NeighbourImages.js');
-var ClusterPlot = require('./ClusterPlot.js');
 var Spinner = require('spin.js');
 var spinner = new Spinner();
 
@@ -78,7 +77,6 @@ function mountPlots(screenData, sampleData, featureNames) {
     var histogram = new Histogram(sampleData, '#histplot' ,featureNames);
     var lineplot = new Lineplot(sampleData, '#lineplot', histogram);
     var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot', lineplot, neighbourImages);
-    var clusterPlot = new ClusterPlot(sampleData, '#clusterpcaplot');
     var filter = new Filter(sampleData, neighbourPlot);
 }
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -72,17 +72,9 @@ function selectScreen(screen_id) {
 }
 
 function mountPlots(screenData, sampleData, featureNames) {
-    updateTab(screenData);
     var neighbourImages = new NeighbourImages(sampleData[0]._id);
     var histogram = new Histogram(sampleData, '#histplot' ,featureNames);
     var lineplot = new Lineplot(sampleData, '#lineplot', histogram);
     var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot', lineplot, neighbourImages);
     var filter = new Filter(sampleData, neighbourPlot);
-}
-
-// update summary tab
-function updateTab(screen_data) {
-    $('#name').text(screen_data._id);
-    $('#desc').text(screen_data.screen_desc);
-    $('#samples').text(screen_data.number_samples);
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -79,7 +79,7 @@ function selectScreen(screen_id) {
 function mountPlots(screenData, sampleData, featureNames) {
     var neighbourImages = new NeighbourImages();
     var histogram = new Histogram(sampleData, '#histplot' ,featureNames);
-    var lineplot = new Lineplot(sampleData, '#lineplot', histogram);
+    var lineplot = new Lineplot(sampleData, '#lineplot');
     var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot');
     var filter = new Filter(sampleData, neighbourPlot);
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -14,6 +14,10 @@ $(document).ready(function() {
         async: false,
         success: function (json) {
             updateSelector(json);
+            // automatically select a screen if there is only one to choose from
+            if(json.length === 1) {
+                selectScreen(json[0]._id);
+            }
         },
         dataType: 'json'
     });

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -77,9 +77,9 @@ function selectScreen(screen_id) {
 }
 
 function mountPlots(screenData, sampleData, featureNames) {
-    var neighbourImages = new NeighbourImages(sampleData[0]._id);
+    var neighbourImages = new NeighbourImages();
     var histogram = new Histogram(sampleData, '#histplot' ,featureNames);
     var lineplot = new Lineplot(sampleData, '#lineplot', histogram);
-    var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot', neighbourImages);
+    var neighbourPlot = new NeighbourPlot(sampleData, '#neighbourplot');
     var filter = new Filter(sampleData, neighbourPlot);
 }


### PR DESCRIPTION
I've marked this WIP because there's still a couple of bits and pieces to be done, such as updating the docstrings to relfect the changes I've made. However the functionality is there if we want to try putting the branch online.

Other updates in this PR include:
* If only one screen is found in the Mongo collection, this is loaded automatically.
* Clicking on the images triggers an update of the active selected point, so its position in the PCA plot and feature distribution in the linegraph are displayed.
* When a point is clicked, it's brought to the top of the SVG stack.
* A few quick optimizations, such as caching jQuery selectors.