### PR TITLE
[WIP] Update server/configs before putting demo online

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,4 +1,6 @@
 module.exports = {
     // the database url
-    url : 'mongodb://localhost/microscopium'
-}
+    url : process.env.MONGO_URL || 'mongodb://localhost/microscopium',
+    mongoUser: process.env.MONGO_USER,
+    mongoPassword: process.env.MONGO_PASSWORD
+};

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -68,4 +68,6 @@ module.exports = function(grunt) {
     grunt.registerTask('default', ['express:dev', 'browserify:tests',
         'browserify:dev', 'jasmine:dev', 'jshint:all', 'watch']);
 
+    grunt.registerTask('build', ['browserify:dev']);
+
 };

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
     "name": "microscopium-ui",
     "main": "server.js",
+    "scripts": {
+        "postinstall": "bower install && grunt build"
+    },
     "dependencies": {
         "body-parser": "~1.12.0",
+        "bower": "~1.4.1",
         "compression": "~1.4.3",
         "d3": "~3.5.5",
         "d3-tip": "~0.6.7",

--- a/server.js
+++ b/server.js
@@ -1,14 +1,20 @@
 // modules
 var express = require('express');
-var compression = require('compression')
+var compression = require('compression');
 var app = express();
 var logger = require('morgan');
 var bodyParser = require('body-parser');
 var mongoose = require('mongoose');
 
+// read port from environment, otherwise default to 8080
+var port = process.env.PORT || 8080;
+
 // setup db
 var db = require('./config/db');
-mongoose.connect(db.url);
+mongoose.connect(db.url, {
+    user: db.mongoUser,
+    pass: db.mongoPassword
+});
 
 // setup app
 app.use(logger('dev'));
@@ -23,5 +29,5 @@ app.use(express.static(__dirname + '/public'));
 require('./app/routes')(app);
 
 //startup
-app.listen(8080);
-console.log('Server started on port 8080..');
+app.listen(port);
+console.log('Server started on port ' + port  + '..');


### PR DESCRIPTION
I don't want to merge this just yet, but I'll use this branch to track any updates made to the backend before merging to master and putting the demo online.

* The port is read from the PORT env variable, otherwise it defaults 8080 if this isn't set.
* The Mongo URL, username and password are read from env variables -- if these aren't set, then it'll try and connect to the unsecured ``mongodb://localhost/microscopium`` instance.