### PR TITLE
Add backwards and forwards buttons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -47,7 +47,8 @@
     background-color: #000000;
 }
 
-.fa-filter {
+/* resize font-awesome icons (they all belong to the fa class) */
+.fa {
     font-size: 1.3em;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,17 @@
             <!-- RIGHT NAV -->
             <ul class="nav navbar-nav navbar-right">
                 <li>
+                    <a href="#" id="back-button" class="hidden">
+                        <i class="fa fa-arrow-left"></i>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" id="forward-button" class="hidden">
+                        <i class="fa fa-arrow-right"></i>
+                    </a>
+                </li>
+                <!-- FILTER ICON -->
+                <li>
                     <a href="#" id="filter-button" class="sb-toggle-right hidden">
                         <i class="fa fa-filter"></i>
                     </a>

--- a/public/js/History.js
+++ b/public/js/History.js
@@ -7,7 +7,8 @@
  */
 function History() {
     this.sampleHistory = [];
-    this.iterator = 0;
+    this.current = -1;
+    this.lastSample = null;
     this.length = 0;
 }
 
@@ -20,17 +21,21 @@ function History() {
  * @param {string} sampleId - The sampleID to add to the history.
  */
 History.prototype.add = function(sampleId) {
-    this.iterator++;
-    if(this.iterator === this.sampleHistory.length) {
-        // append to the history array if needed
-        this.sampleHistory.push(sampleId);
+    // only add a new item to the history if it was not just added
+    if(this.lastSample !== sampleId) {
+        // add new entry to array if no more space in current history
+        if(this.current === this.sampleHistory.length-1) {
+            this.current++;
+            this.sampleHistory.push(sampleId);
+        }
+        else {
+            // otherwise overwrite old history if room in array
+            this.current++;
+            this.sampleHistory[this.current] = sampleId;
+        }
+        this.lastSample = sampleId;
+        this.length = this.current+1;
     }
-    else {
-        // otherwise overwrite old history if room in array
-        this.sampleHistory[this.iterator] = sampleId;
-    }
-    // the length of the history will be equal to the iterator after adding
-    this.length = this.iterator;
 };
 
 /**
@@ -42,9 +47,9 @@ History.prototype.add = function(sampleId) {
  * @returns {string|null} The previous item in the list of samples.
  */
 History.prototype.back = function() {
-    if(this.iterator > 0) {
-        this.iterator--;
-        return this.sampleHistory[this.iterator];
+    if(this.current > 0) {
+        this.current--;
+        return this.sampleHistory[this.current];
     }
     else {
         return null;
@@ -59,9 +64,9 @@ History.prototype.back = function() {
  * @returns {string|null}
  */
 History.prototype.forward = function() {
-    if(this.iterator < this.sampleHistory.length - 1) {
-        this.iterator++;
-        return this.sampleHistory[this.iterator];
+    if(this.current > -1 && this.current < this.sampleHistory.length-1) {
+        this.current++;
+        return this.sampleHistory[this.current];
     }
     else {
         return null;
@@ -75,7 +80,7 @@ History.prototype.forward = function() {
  */
 History.prototype.reset = function() {
     this.sampleHistory = [];
-    this.iterator = 0;
+    this.current = -1;
     this.length = 0;
 };
 

--- a/public/js/History.js
+++ b/public/js/History.js
@@ -1,0 +1,81 @@
+/**
+ * History: Keep track of user's sample history.
+ *
+ * This object emulates the typical back/forward behaviour in browsers.
+ *
+ * @constructor
+ */
+function History() {
+    this.sampleHistory = [];
+    this.iterator = 0;
+    this.length = this.sampleHistory.length;
+    this.lastSample = null;
+}
+
+/**
+ * add: Adds an item to the history.
+ *
+ * Any elements after the current iterator are removed.
+ *
+ * @this {History}
+ * @param {string} sampleId - The sampleID to add to the history.
+ */
+History.prototype.add = function(sampleId) {
+    if(sampleId !== this.lastSample) {
+        this.sampleHistory = this.sampleHistory.slice(0, this.iterator+1);
+        this.sampleHistory.push(sampleId);
+        this.iterator = this.sampleHistory.length - 1;
+        this.length = this.sampleHistory.length;
+        this.lastSample = sampleId;
+    }
+};
+
+/**
+ * back: Go back one item in the history.
+ *
+ * Returns null if there is no items to return.
+ *
+ * @this {History}
+ * @returns {string|null} The previous item in the list of samples.
+ */
+History.prototype.back = function() {
+    if(this.iterator > 0) {
+        this.iterator--;
+        return this.sampleHistory[this.iterator];
+    }
+    else {
+        return null;
+    }
+};
+
+/**
+ * forward: Go forward one item in the history.
+ *
+ * Returns null if there are no items to return.
+ *
+ * @returns {string|null}
+ */
+History.prototype.forward = function() {
+    if(this.iterator < this.sampleHistory.length - 1) {
+        this.iterator++;
+        return this.sampleHistory[this.iterator];
+    }
+    else {
+        return null;
+    }
+};
+
+/**
+ * reset: Reset all items in the history.
+ *
+ * @this {History}
+ */
+History.prototype.reset = function() {
+    this.sampleHistory = [];
+    this.iterator = 0;
+    this.lastSample = null;
+    this.length = this.sampleHistory.length;
+};
+
+module.exports = History;
+

--- a/public/js/History.js
+++ b/public/js/History.js
@@ -8,8 +8,7 @@
 function History() {
     this.sampleHistory = [];
     this.iterator = 0;
-    this.length = this.sampleHistory.length;
-    this.lastSample = null;
+    this.length = 0;
 }
 
 /**
@@ -21,13 +20,17 @@ function History() {
  * @param {string} sampleId - The sampleID to add to the history.
  */
 History.prototype.add = function(sampleId) {
-    if(sampleId !== this.lastSample) {
-        this.sampleHistory = this.sampleHistory.slice(0, this.iterator+1);
+    this.iterator++;
+    if(this.iterator === this.sampleHistory.length) {
+        // append to the history array if needed
         this.sampleHistory.push(sampleId);
-        this.iterator = this.sampleHistory.length - 1;
-        this.length = this.sampleHistory.length;
-        this.lastSample = sampleId;
     }
+    else {
+        // otherwise overwrite old history if room in array
+        this.sampleHistory[this.iterator] = sampleId;
+    }
+    // the length of the history will be equal to the iterator after adding
+    this.length = this.iterator;
 };
 
 /**
@@ -73,8 +76,7 @@ History.prototype.forward = function() {
 History.prototype.reset = function() {
     this.sampleHistory = [];
     this.iterator = 0;
-    this.lastSample = null;
-    this.length = this.sampleHistory.length;
+    this.length = 0;
 };
 
 module.exports = History;

--- a/public/js/History.js
+++ b/public/js/History.js
@@ -28,8 +28,8 @@ History.prototype.add = function(sampleId) {
             this.current++;
             this.sampleHistory.push(sampleId);
         }
+        // otherwise overwrite old history if room in array
         else {
-            // otherwise overwrite old history if room in array
             this.current++;
             this.sampleHistory[this.current] = sampleId;
         }
@@ -47,7 +47,7 @@ History.prototype.add = function(sampleId) {
  * @returns {string|null} The previous item in the list of samples.
  */
 History.prototype.back = function() {
-    if(this.current > 0) {
+    if(this.current > 0 && this.length > 0) {
         this.current--;
         return this.sampleHistory[this.current];
     }
@@ -64,7 +64,7 @@ History.prototype.back = function() {
  * @returns {string|null}
  */
 History.prototype.forward = function() {
-    if(this.current > -1 && this.current < this.sampleHistory.length-1) {
+    if(this.current > -1 && this.current < this.length-1) {
         this.current++;
         return this.sampleHistory[this.current];
     }

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -206,9 +206,11 @@ NeighbourPlot.prototype.updatePoint = function(sampleId) {
                     .attr('r', self.inactivePointRadius);
             }
 
-            // set class and attr of new active point
+            // set class and attr of new active point and
+            // remove click event listener
             selectedPoint
                 .classed('activept', true)
+                .on('click', null)
                 .moveToFront()
                 .transition()
                 .duration(self.transitionDuration)

--- a/public/js/NeighbourPlot.js
+++ b/public/js/NeighbourPlot.js
@@ -210,7 +210,6 @@ NeighbourPlot.prototype.updatePoint = function(sampleId) {
             // remove click event listener
             selectedPoint
                 .classed('activept', true)
-                .on('click', null)
                 .moveToFront()
                 .transition()
                 .duration(self.transitionDuration)

--- a/tests/History.spec.js
+++ b/tests/History.spec.js
@@ -1,0 +1,60 @@
+var History = require('../public/js/History.js');
+
+describe('History', function() {
+    var history;
+
+    beforeEach(function() {
+        history = new History();
+    });
+
+    describe('add', function() {
+        it('should not add the same item consecutively', function() {
+            history.add('A');
+            history.add('A');
+            expect(history.length).toEqual(1);
+        });
+    });
+
+    describe('back', function() {
+        it('should return null if nothing to return', function() {
+            expect(history.back()).toBeNull();
+        });
+
+        it('should return items in expected order', function() {
+            ['A', 'B', 'C'].forEach(function(value) {
+                history.add(value);
+            });
+            var actual = [];
+            actual.push(history.back());
+            actual.push(history.back());
+            expect(actual).toEqual(['B', 'A']);
+        });
+    });
+
+    describe('forward', function() {
+        it('should return null if nothing to return', function() {
+            expect(history.forward()).toBeNull();
+        });
+
+        it('should return items in expected order', function() {
+            ['A', 'B', 'C'].forEach(function(value) {
+                history.add(value);
+            });
+            var actual = [];
+            history.back();
+            history.back();
+            actual.push(history.forward());
+            actual.push(history.forward());
+            expect(actual).toEqual(['B', 'C']);
+        });
+    });
+
+    describe('reset', function() {
+        it('should remove all items from history', function() {
+            history.add('A');
+            history.add('B');
+            history.reset();
+            expect(history.length).toEqual(0);
+        });
+    });
+});

--- a/tests/History.spec.js
+++ b/tests/History.spec.js
@@ -7,14 +7,6 @@ describe('History', function() {
         history = new History();
     });
 
-    describe('add', function() {
-        it('should not add the same item consecutively', function() {
-            history.add('A');
-            history.add('A');
-            expect(history.length).toEqual(1);
-        });
-    });
-
     describe('back', function() {
         it('should return null if nothing to return', function() {
             expect(history.back()).toBeNull();
@@ -47,14 +39,40 @@ describe('History', function() {
             actual.push(history.forward());
             expect(actual).toEqual(['B', 'C']);
         });
+
+        it('it should return the expected order going back, forward and adding', function() {
+            var actual = [];
+            ['A', 'B', 'C'].forEach(function(value) {
+                history.add(value);
+            });
+            history.back();
+            history.add('D');
+            actual.push(history.back());
+            actual.push(history.back());
+            actual.push(history.forward());
+            actual.push(history.forward());
+            expect(actual).toEqual(['B', 'A', 'B', 'D']);
+        });
+    });
+
+    describe('length', function() {
+        it('should return the correct length', function() {
+            ['A', 'B', 'C'].forEach(function(value) {
+                history.add(value);
+            });
+            history.back();
+            history.add('D');
+            expect(history.length).toEqual(3);
+        });
     });
 
     describe('reset', function() {
         it('should remove all items from history', function() {
-            history.add('A');
-            history.add('B');
+            var actual = [];
             history.reset();
-            expect(history.length).toEqual(0);
+            actual.push(history.back());
+            actual.push(history.forward());
+            expect(actual).toEqual([null, null]);
         });
     });
 });

--- a/tests/History.spec.js
+++ b/tests/History.spec.js
@@ -3,8 +3,20 @@ var History = require('../public/js/History.js');
 describe('History', function() {
     var history;
 
+    // reset history object before each spec
     beforeEach(function() {
         history = new History();
+    });
+
+    describe('add', function() {
+        it('should not add the same item consecutively', function() {
+            var actual = [];
+            history.add('A');
+            history.add('A');
+            actual.push(history.back());
+            actual.push(history.forward());
+            expect(actual).toEqual([null, null]);
+        });
     });
 
     describe('back', function() {
@@ -12,11 +24,20 @@ describe('History', function() {
             expect(history.back()).toBeNull();
         });
 
+        it('should return null when no more items in history', function() {
+            var actual = [];
+            history.add('A');
+            history.add('B');
+            actual.push(history.back());
+            actual.push(history.back());
+            expect(actual).toEqual(['A', null])
+        });
+
         it('should return items in expected order', function() {
+            var actual = [];
             ['A', 'B', 'C'].forEach(function(value) {
                 history.add(value);
             });
-            var actual = [];
             actual.push(history.back());
             actual.push(history.back());
             expect(actual).toEqual(['B', 'A']);
@@ -40,6 +61,16 @@ describe('History', function() {
             expect(actual).toEqual(['B', 'C']);
         });
 
+        it('should return null when no more items in history', function() {
+            var actual = [];
+            history.add('A');
+            history.add('B');
+            actual.push(history.back());
+            actual.push(history.forward());
+            actual.push(history.forward());
+            expect(actual).toEqual(['A', 'B', null]);
+        });
+
         it('it should return the expected order going back, forward and adding', function() {
             var actual = [];
             ['A', 'B', 'C'].forEach(function(value) {
@@ -52,17 +83,6 @@ describe('History', function() {
             actual.push(history.forward());
             actual.push(history.forward());
             expect(actual).toEqual(['B', 'A', 'B', 'D']);
-        });
-    });
-
-    describe('length', function() {
-        it('should return the correct length', function() {
-            ['A', 'B', 'C'].forEach(function(value) {
-                history.add(value);
-            });
-            history.back();
-            history.add('D');
-            expect(history.length).toEqual(3);
         });
     });
 

--- a/tests/History.spec.js
+++ b/tests/History.spec.js
@@ -95,4 +95,19 @@ describe('History', function() {
             expect(actual).toEqual([null, null]);
         });
     });
+
+    describe('length', function() {
+        it('should return the correct length', function() {
+            history.add('A');
+            history.add('B');
+            history.add('C');
+            history.back();
+            history.add('D');
+            history.add('E');
+            history.add('F');
+            history.back();
+            history.add('G');
+            expect(history.length).toEqual(5);
+        });
+    });
 });


### PR DESCRIPTION
This PR adds buttons to the top menu bar that let a user go backwards and forwards between samples they've chosen.
![backwards-forwards](https://cloud.githubusercontent.com/assets/7637964/7697145/07e963a6-fe48-11e4-9bbf-d62e1e432b19.png)
