### PR TITLE
Add point colour overlays for displaying z-scores (or other info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Prerequisites
 * NPM package manager
 * Bower package manager
 * MongoDB version > 2.6
-* A modern browser, at least IE10+ or equivalent.
+* A modern browser. The interface is tested as working on 
+    latest Chrome, Firefox, Edge and IE11. Due to the heavy use of the HTML5Canvas API,
+    performance is best on Chrome.
 
 Install Instructions (Development)
 ----------------------------------
@@ -71,9 +73,14 @@ following format:
 var Screen = {
     _id: String, // A short ID for the screen.
     screen_desc: String, // A description of the screen.
-    number_samples: Number // The number of
-    screen_features: Array // An array of strings labelling each feature used in
+    number_samples: Number, // The number of
+    screen_features: Array, // An array of strings labelling each feature used in
                            // the screen.
+    available_overlays: Array // An optional field. An array of additional overlay
+                              // information available for samples in this screen.
+                              // e.g. if samples have ``screen_run`` and ``z_score``
+                              // overlay information, this array should be 
+                              // ["screen_run", "z_score"]
 }
 ```
 
@@ -89,7 +96,7 @@ var Sample = {
                             // applied to the sample.
         feature_vector: Array,  // An array of Numbers, the vector of
                                 // unstandardised features
-        featute_vector_std: Array  // An array of Numbers, the vector of standardised
+        feature_vector_std: Array  // An array of Numbers, the vector of standardised
                                    // features.
         neighbours: Array  // An array of sample_id strings, the 25 nearest
                            // neighbours of the sample.
@@ -101,10 +108,11 @@ var Sample = {
             pca: Array // the co-ordinates for the sample's point after PCA dimension reduction
             tsne: Array // the co-ordinates for the sample's point after TSNE dimension reduction
         },
-        image: ObjectID, // image_id  The ID of the samples image document
-                         // (see below).
-        cluster_member: Array // Array of integers showing cluster memberships
-                              // for clustering scheme k=2..20
+        overlays: Object // An object of the additional screen overlay information
+                         // for this sample. This information is optional. If no 
+                         // overlay information is available, the corresponding
+                         // sample document should no, or an empty, ``available_overlays``
+                         // field. Currently supports numeric and Date data.
     }
 ```
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -28,13 +28,17 @@ def load_screen(screen_id):
         flash("Unable to find screen %s." % screen_id)
         return redirect(url_for(".index"))
 
+    # get the overlays object if it exists
+    overlays = screen_result.get("available_overlays")
+
     # get list of screens in database, exclude "screen_features" field as
     # we don't need it here
     screens = mongo.db.screens.find({}, fields={"screen_features": False})
 
     return render_template("screen_ui.html",
                            screen_id=screen_id,
-                           screens=screens)
+                           screens=screens,
+                           overlays=overlays)
 
 @main.after_request
 def minify_html_response(response):

--- a/app/static/config/plots.js
+++ b/app/static/config/plots.js
@@ -69,7 +69,20 @@ module.exports = {
                 radius: 5
             }
         },
-        scaleExtent: [1, 10]
+        // the minimum/maxium scale factor allowed when zooming into the scatterplot
+        zoomExtent: [1, 12],
+        // the colourscale to use when plotting overlays to the neighbourplot
+        // should be one of the new matplot scales: inferno, magma, plasma or viridis
+        // see: https://bids.github.io/colormap/
+        colourScale: 'viridis',
+        // the minimum and maximum z scores to display on the colourmap
+        // outside the range will be clamped
+        colourScaleExtent: [-4, 4]
+    },
+    neighbourPlotLegend: {
+        width: 230,
+        height: 50,
+        margin: {top: 5, bottom: 20, left: 5, right: 5}
     },
     featureVectorlinePlot: {
         // create space between the x and y axis. this value is a pct of the

--- a/app/static/config/plots.js
+++ b/app/static/config/plots.js
@@ -77,7 +77,7 @@ module.exports = {
         colourScale: 'viridis',
         // the minimum and maximum z scores to display on the colourmap
         // outside the range will be clamped
-        colourScaleExtent: [-4, 4]
+        colourScaleExtent: [-3, 3]
     },
     neighbourPlotLegend: {
         width: 230,

--- a/app/static/css/main.scss
+++ b/app/static/css/main.scss
@@ -43,6 +43,10 @@
   font-size: 1.3em;
 }
 
+.fa-hidden {
+  visibility: hidden;
+}
+
 /* Image Modal Styles */
 
 .modal-dialog {

--- a/app/static/css/neighbourplot.scss
+++ b/app/static/css/neighbourplot.scss
@@ -14,6 +14,10 @@
   shape-rendering: crispEdges;
 }
 
+.axis.legend text {
+  font: 10px sans-serif;
+}
+
 #neighbourplot-options {
   text-align: left;
 }

--- a/app/static/js/NeighbourPlotCanvas.js
+++ b/app/static/js/NeighbourPlotCanvas.js
@@ -6,10 +6,6 @@ var config = require('../config/plots').neighbourPlot;
 // browserify can't load modules dynamically due to the way it statically
 // analyses paths when creating the output bundle. in other words, no variables
 // or concatenated strings can be used in required paths.
-// this switch is inelegant and should be replaced with something nicer
-// maybe this could be configured server-side maybe when matplotlib 1.5 is
-// released and these colour scales become available??
-// TODO replace this whole godfawful switch
 var colourMap;
 switch(config.colourScale) {
     case 'inferno':
@@ -162,7 +158,7 @@ NeighbourPlotCanvas.prototype.updateOverlay = function(overlay) {
             .clamp(true);
     }
 
-    // new new colourscale to pointsdrawer
+    // send new colourscale to pointsdrawer
     this.pointsDrawer.setColourScale(colourScale);
     this.plotLegend.setColourScale(colourScale);
 
@@ -283,46 +279,53 @@ NeighbourPlotCanvas.prototype._createCanvasSVGSelectors = function() {
         .style('z-index', 1)
         .style('position', 'absolute')
         .append('g')
-        .attr('transform', 'translate(' + this.margin.left + ',' +
-            this.margin.top + ')');
+        .attr('transform',
+            Utils.translateString(this.margin.left, this.margin.top, false));
 
     // create canvas element and set height and translation of the canvas
     // used to draw the plot points -- the height and width is set to
     // the full height and width minus the margins, and is translated so it
     // sits 'above' the plot axis. the canvas is shifted up one pixel
     // to prevent any artefacts from the canvas and axis avg overlapping
+    var pointsLeft = this.margin.left + 1;
+    var pointsTop = this.margin.top + 1;
     this.pointsCanvas = parentDiv.append('canvas')
         .attr('width', this.width - 1)
         .attr('height', this.height - 1)
-        .style('transform', 'translate(' + (this.margin.left + 1) +
-            'px' + ',' + (this.margin.top + 1) + 'px)')
+        .style('transform', Utils.translateString(pointsLeft, pointsTop, true))
         .style('z-index', 2)
         .style('position', 'absolute');
 
     // create an svg element that sits on top of the points canvas we
     // just defined above
     // this SVG catches events and is used to draw the tooltip element
+    var mainLeft = this.margin.left + 1;
+    var mainTop = this.margin.top + 1;
     this.mainSvg = parentDiv.append('svg')
         .attr('width', this.width - 1)
         .attr('height', this.height - 1)
-        .style('transform', 'translate(' + (this.margin.left + 1) +
-            'px' + ',' + (this.margin.top + 1) + 'px)')
+        .style('transform', Utils.translateString(mainLeft, mainTop, true))
         // an svg transform should be applied to the SVG element too
         // as we've shifted its position using CSS.
         // note we don't specify pixels -- it's not a CSS transformation
-        .attr('transform', 'translate(' + (this.margin.left + 1) + ',' +
-            (this.margin.top + 1) + ')')
+        .attr('transform', Utils.translateString(mainLeft, mainTop, false))
         // this element should have the greatest z-index so it catches
         // mouse events
         .style('z-index', 3)
         .style('position', 'absolute');
 
     // SVG for drawing legend
+    // want to translate the legend left the width of the scatterplot
+    // less some margin so there's space to the right of it
+    var legendLeft = this.width + this.margin.left -
+        legendConfig.width - legendConfig.margin.right;
+    // want to translate the legend down slightly so there's space above it
+    var legendTop = this.margin.top + legendConfig.margin.top;
     this.legendSvg = parentDiv.append('svg')
         .attr('width', legendConfig.width)
         .attr('height', legendConfig.height)
-        .style('transform', 'translate(' + (this.margin.left + 1 + this.width
-            - legendConfig.width - 5) + 'px' + ',' + (this.margin.top + 5) + 'px)')
+        .style('transform',
+            Utils.translateString(legendLeft, legendTop, true))
         .style('z-index', 4)
         .style('position', 'absolute');
 };

--- a/app/static/js/PlotLegend.js
+++ b/app/static/js/PlotLegend.js
@@ -1,0 +1,122 @@
+var d3 = require('d3');
+var _ = require('lodash');
+var Utils = require('./utils/Utils.js');
+var config = require('../config/plots.js').neighbourPlotLegend;
+
+/**
+ * PlotLegend: Handle creation/updating of the legend in the Neighbourplot.
+ *
+ * @param svg
+ * @constructor
+ */
+function PlotLegend(svg) {
+    this.svg = svg;
+}
+
+/**
+ * setColourScale: Draw the legend for the given colour scale.
+ *
+ * @param scale {Function} - Instance of a d3.scale.linear() where the range
+ *     is an array of colours. (i.e a colour scale).
+ */
+PlotLegend.prototype.setColourScale = function(scale) {
+    this.svg.selectAll('*').remove();
+
+
+    // if no scale is passed to the function, we're happy
+    // just to remove the SVG elements and return out of the function
+    if(_.isNull(scale) || _.isUndefined(scale)) {
+        return;
+    }
+
+    // otherwise go on and create the legend..
+    this.scale = scale;
+
+    this._addBackground();
+    this._addLegendGradient();
+    this._setAxis();
+};
+
+/**
+ * addBackground: Add a solid white background to the plot legend.
+ *
+ * @private
+ */
+PlotLegend.prototype._addBackground = function() {
+    this.svg.append('rect')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('width', config.width)
+        .attr('height', config.height)
+        .attr('fill', 'white')
+        .style('stroke', 'black')
+        .style('stroke-width', 1);
+};
+
+/**
+ * addLegendGradient: Add colour gradient for the plot legend.
+ *
+ * @private
+ */
+PlotLegend.prototype._addLegendGradient = function() {
+    // create linear gradient def going from left to right
+    var gradient = this.svg.append('defs')
+        .append('linearGradient')
+        .attr('id', 'gradient')
+        .attr('x1', '0%') // left
+        .attr('y1', '100%')
+        .attr('x2', '100%') // to right
+        .attr('y2', '100%')
+        .attr('spreadMethod', 'pad');
+
+    // programatically generate the gradient for the legend
+    // this creates an array of [pct, colour] pairs as stop
+    // values for legend
+    var pct = Utils.linspace(0, 100, this.scale.range().length)
+        .map(function(d) {
+            return Math.round(d) + '%';
+        });
+    var colourPct = d3.zip(pct, this.scale.range());
+
+    colourPct.forEach(function(d) {
+        gradient.append('stop')
+            .attr('offset', d[0])
+            .attr('stop-color', d[1])
+            .attr('stop-opacity', 1);
+    });
+
+    // now append the legend
+    this.svg.append('rect')
+        .attr('x', config.margin.left)
+        .attr('y', config.margin.top)
+        .attr('width', config.width - config.margin.left - config.margin.right)
+        .attr('height', config.height - config.margin.top - config.margin.bottom)
+        .style('fill', 'url(#gradient)');
+};
+
+/**
+ * setAxis: Add an axis to the plot legend.
+ *
+ * @private
+ */
+PlotLegend.prototype._setAxis = function() {
+    var colorScaleMin = this.scale.domain()[0];
+    var colorScaleMax = this.scale.domain().slice(-1)[0];
+
+    var legendScale = d3.scale.linear()
+        .domain([colorScaleMin, colorScaleMax])
+        .range([0, config.width - config.margin.left - config.margin.right]);
+
+    var legendAxis = d3.svg.axis()
+        .scale(legendScale)
+        .orient("bottom")
+        .ticks(3);
+
+    this.svg.append("g")
+        .attr("class", "legend axis")
+        .attr("transform", "translate(" + config.margin.left + ", " +
+            (config.height - config.margin.bottom) + ")")
+        .call(legendAxis);
+};
+
+module.exports = PlotLegend;

--- a/app/static/js/PlotLegend.js
+++ b/app/static/js/PlotLegend.js
@@ -22,7 +22,6 @@ function PlotLegend(svg) {
 PlotLegend.prototype.setColourScale = function(scale) {
     this.svg.selectAll('*').remove();
 
-
     // if no scale is passed to the function, we're happy
     // just to remove the SVG elements and return out of the function
     if(_.isNull(scale) || _.isUndefined(scale)) {

--- a/app/static/js/PointsDrawer.js
+++ b/app/static/js/PointsDrawer.js
@@ -16,14 +16,6 @@ function PointsDrawer(canvas) {
     this.context = canvas.node().getContext('2d');
 
     this.overlay = 'None';
-
-    // default colourscale
-    // this colourscale is used when no overlay is active
-    this.defaultColourScale = d3.scale.linear()
-        .range([config.pointStyle.defaultStyle.fillStyle,
-            config.pointStyle.defaultStyle.fillStyle])
-        .clamp(true);
-    this.colourScale = this.defaultColourScale;
 }
 
 /**
@@ -98,12 +90,11 @@ PointsDrawer.prototype.redraw = function (data, indices) {
 };
 
 PointsDrawer.prototype.setColourScale = function(colourScale) {
-    // if no custom colour scale provided, use the default
     if(_.isNull(colourScale) || _.isUndefined(colourScale)) {
         this.colourScale = this.defaultColourScale;
     }
     else {
-        this.colourScale = colourScale;
+        this.colourScale = null;
     }
 };
 
@@ -154,19 +145,22 @@ PointsDrawer.prototype._drawPoint = function(point, r, fill) {
     var cx = this.xScale(point.dimension_reduce[this.view][0]);
     var cy = this.yScale(point.dimension_reduce[this.view][1]);
 
-    // if a fill has not been explicitly defined, use the colourscale
     if(_.isNull(fill) || _.isUndefined(fill)) {
-        // if no overlay defined, pass a value to the default colour scale
+        // if a fill has not been explicitly defined, use the colourscale if it's
+        // defined
         if(!_.isNull(point.overlays) && !_.isUndefined(point.overlays)) {
             this.context.fillStyle =
                 this.colourScale(point.overlays[this.overlay] || 0);
         }
+        // otherwise use the default fill style
         else {
             this.context.fillStyle =
-                this.colourScale(0);
+                config.pointStyle.defaultStyle.fillStyle;
         }
     }
     else {
+        // if a fill style is passed to the function, use it when styling
+        // the point
         this.context.fillStyle = fill;
     }
 

--- a/app/static/js/UIController.js
+++ b/app/static/js/UIController.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var History = require('./History.js');
 var Filter = require('./Filter.js');
 var FeatureDistributionHistogram = require('./FeatureDistributionHistogram.js');

--- a/app/static/js/UIController.js
+++ b/app/static/js/UIController.js
@@ -82,6 +82,7 @@ UIController.prototype.updateFeature = function(activeFeature) {
  * updatePoint: Handle view/plot updates when 'updateSample' event triggered.
  *
  * @this {UIController}
+ * @param sampleId {string} - The sample_id of the new sample to display.
  */
 UIController.prototype.updateSample = function(sampleId) {
     this.history.add(sampleId);
@@ -91,6 +92,26 @@ UIController.prototype.updateSample = function(sampleId) {
     this.neighbourImages.getImages(sampleId);
 };
 
+/**
+ * updateOverlay: Handle view/plot updates when 'updateOverlay' event triggered.
+ *
+ * @param overlay {string} - The new overlay to use to colour the points on the plot.
+ *     Will default to "None" and remove any overlay if this argument isn't passed.
+ */
+UIController.prototype.updateOverlay = function(overlay) {
+    if(_.isNull(overlay) || _.isUndefined(overlay)) {
+        overlay = "None";
+    }
+    this.neighbourPlotCanvas.updateOverlay(overlay);
+};
+
+/**
+ * updateView: Handle view/plot updates when 'updateView' event triggered.
+
+ * @this {UIController}
+ * @param dimension {string} - The dimensionality reduction method to use when
+ *     displaying the plot points.
+ */
 UIController.prototype.updateView = function(dimension) {
     this.neighbourPlotCanvas.updateView(dimension);
 };

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -26,7 +26,7 @@ $(document).ready(function() {
     var sampleQuery = $.ajax({
         type: 'GET',
         url: '/api/' + SCREEN_ID + '/samples?' + $.param({
-            'select': ['row', 'column', 'plate', 'gene_name', 'dimension_reduce']
+            'select': ['row', 'column', 'plate', 'gene_name', 'dimension_reduce', 'overlays']
         }, true),
         dataType: 'json',
         async: true,
@@ -121,6 +121,13 @@ $(document).ready(function() {
                 // handle plot/ui update logic
                 uiController.updateView(val);
             }
+        });
+
+        $('#overlay-select a').on('click', function() {
+            $('#overlay-select i').addClass('fa-hidden');
+            $(this).children().removeClass('fa-hidden');
+            var val = $(this).text().trim();
+            uiController.updateOverlay(val);
         });
 
         $('a.navbar-brand').on('click', function() {

--- a/app/static/js/utils/Utils.js
+++ b/app/static/js/utils/Utils.js
@@ -88,4 +88,67 @@ Utils.euclideanDistance = function(x1, y1, x2, y2) {
     return Math.sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
 };
 
+/**
+ * linspace: Return a linearly spaced array.
+ *
+ * Like Numpy/MATLABs linspace method, this generates an array
+ * of n evenly spaced values in the range [start, end]. The start
+ * and end values are always included in the output.
+ *
+ * @param start {number} - The first value.
+ * @param end {number} - The last value.
+ * @param n - {number}
+ * @returns {Array} - The linearly spaced array.
+ */
+Utils.linspace = function(start, end, n) {
+    var out = [];
+    var delta = (end - start) / (n - 1);
+
+    var i = 0;
+    while(i < (n - 1)) {
+        out.push(start + (i * delta));
+        i++;
+    }
+
+    out.push(end);
+    return out;
+};
+
+/**
+ * percentile: Return the n-th percentile of a sorted array.
+ *
+ * Given a sorted array of numbers, find the n-th percentile. This function
+ * finds the linear interpolation by closest ranks method.
+ *
+ * @param data {Array} - The query Array. This is assumed to be sorted.
+ * @param percentile {number} - Number in the range [0.0, 1.0]. The percentile
+ *     to find.
+ * @returns {number} - The percentile value.
+ */
+Utils.percentile = function(data, percentile) {
+    var index = percentile * (data.length - 1);
+    var r = index % 1;
+    var lower = data[Math.floor(index)];
+    var upper = data[Math.ceil(index)];
+    return r * lower + (1 - r) * upper;
+};
+
+/**
+ * getPercentile: Get the percentiles of an array.
+ *
+ * Given an array of numbers, find the given percentiles. E.g
+ * getPercentiles(queryArray, [0.25, 0.5, 0.75]) will find the 25th,
+ * median and 75th percentile values.
+ *
+ * @param data - {Array} - The query Array. Does not need to be sorted.
+ * @param percentiles {Array} - An array of percentile values to find.
+ * @returns {Array} - The array of percentile values.
+ */
+Utils.getPercentiles = function(data, percentiles) {
+    var sorted = data.sort(function(a, b) { return a - b });
+    return percentiles.map(function(d) {
+        return Utils.percentile(sorted, d);
+    });
+};
+
 module.exports = Utils;

--- a/app/static/js/utils/Utils.js
+++ b/app/static/js/utils/Utils.js
@@ -101,16 +101,14 @@ Utils.euclideanDistance = function(x1, y1, x2, y2) {
  * @returns {Array} - The linearly spaced array.
  */
 Utils.linspace = function(start, end, n) {
-    var out = [];
+    var out = new Array(n - 1);
     var delta = (end - start) / (n - 1);
 
-    var i = 0;
-    while(i < (n - 1)) {
-        out.push(start + (i * delta));
-        i++;
+    for(var i = 0; i < (n - 1); i++) {
+        out[i] = start + (i * delta);
     }
 
-    out.push(end);
+    out[n - 1] = end;
     return out;
 };
 

--- a/app/static/js/utils/Utils.js
+++ b/app/static/js/utils/Utils.js
@@ -149,4 +149,32 @@ Utils.getPercentiles = function(data, percentiles) {
     });
 };
 
+/**
+ * translateString: Create a translate param string for CSS/SVG manipulation.
+ *
+ * In many D3/jQuery functions it's necessary to create a string of the format
+ * "translate(x, y)". This is usually fed to a function that manipulates the
+ * SVG attribute or DOM element style. It gets a little messy creating this
+ * string every time with string concatenation, so this function creates the
+ * string from parameters.
+ *
+ * @param left {Number} - The left/x translation.
+ * @param top {Number} - The right/y translation.
+ * @param px {bool} - Whether or not to add the "px" suffix to the
+ *     left and right params. This is needed for CSS translations as the
+ *     unit of translation must be  given explicitly. This should always be
+ *     false for SVG manipulation as SVG only works in px.
+ */
+Utils.translateString = function(left, top, px) {
+    var out = [];
+    out.push('translate(');
+    out.push(left);
+    out.push(px ? "px" : "");
+    out.push(", ");
+    out.push(top);
+    out.push(px ? "px" : "");
+    out.push(")");
+    return out.join("");
+};
+
 module.exports = Utils;

--- a/app/static/js/utils/Utils.js
+++ b/app/static/js/utils/Utils.js
@@ -91,24 +91,23 @@ Utils.euclideanDistance = function(x1, y1, x2, y2) {
 /**
  * linspace: Return a linearly spaced array.
  *
- * Like Numpy/MATLABs linspace method, this generates an array
+ * Like the Numpy/MATLABs linspace method, this generates an array
  * of n evenly spaced values in the range [start, end]. The start
  * and end values are always included in the output.
  *
  * @param start {number} - The first value.
  * @param end {number} - The last value.
- * @param n - {number}
- * @returns {Array} - The linearly spaced array.
+ * @param n {number} - The length of the linearly spaced array.
+ * @returns out {Array} - The linearly spaced array.
  */
 Utils.linspace = function(start, end, n) {
-    var out = new Array(n - 1);
+    var out = new Array(n);
     var delta = (end - start) / (n - 1);
 
-    for(var i = 0; i < (n - 1); i++) {
+    for(var i = 0; i < n; i++) {
         out[i] = start + (i * delta);
     }
 
-    out[n - 1] = end;
     return out;
 };
 

--- a/app/templates/screen_ui_components/_plots.html
+++ b/app/templates/screen_ui_components/_plots.html
@@ -9,6 +9,28 @@
                 <button type="button" class="btn btn-sm btn-primary btn-dim-select" value="pca">PCA</button>
             </div>
             <button type="button" id="reset-button" class="btn btn-sm btn-primary" value="Reset">Reset</button>
+            {% if overlays %}
+                <b>Sample Overlay: </b>
+                <div id="overlay-select" class="btn-group">
+                    <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown">
+                        Select <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li>
+                            <a href="#">
+                                <i class="fa fa-check"></i>
+                                None
+                            </a>
+                        </li>
+                        {% for overlay in overlays %}
+                            <li><a href="#">
+                                <i class="fa fa-check fa-hidden"></i>
+                                {{ overlay }}
+                            </a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
         </div>
     </div>
     <div class="row">

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "d3-tip": "~0.6.7",
     "lodash": "~3.10.0",
     "lodash-deep": "~1.5.3",
+    "scale-color-perceptual": "^1.1.2",
     "spin.js": "~2.0.2"
   },
   "devDependencies": {

--- a/tests/Utils.spec.js
+++ b/tests/Utils.spec.js
@@ -207,4 +207,18 @@ describe('Utils', function() {
             expect(actual).toEqual(expected)
         });
     });
+
+    describe('translateString', function() {
+        it('returns a translate string with the expected format', function() {
+            var expected = 'translate(100, 75)';
+            var actual = Utils.translateString(100, 75, false);
+            expect(actual).toEqual(expected);
+        });
+
+        it('returns a translate string with the expected format (with px)', function() {
+            var expected = 'translate(100px, 75px)';
+            var actual = Utils.translateString(100, 75, true);
+            expect(actual).toEqual(expected);
+        });
+    });
 });

--- a/tests/Utils.spec.js
+++ b/tests/Utils.spec.js
@@ -152,4 +152,59 @@ describe('Utils', function() {
             expect(actual).toBeCloseTo(expected, precision);
         });
     });
+
+    describe('linspace', function() {
+        it('finds the linearly spaced vector as expected (ascending)', function() {
+            var actual = Utils.linspace(-5, 5, 7);
+            var expected = [-5, -3.33333, -1.66667, 0, 1.66667, 3.33333, 5];
+            var precision = 5;
+
+            // no "array close to" equivilant method, so just check
+            // each element individually
+            for(var i = 0; i < actual.length; i++) {
+                expect(actual[i]).toBeCloseTo(expected[i], precision);
+            }
+        });
+
+        it('finds the linearly spaced vector as expected (descending)', function() {
+            var actual = Utils.linspace(5, -5, 7);
+            var expected = [5, 3.33333, 1.66667, 0, -1.66667, -3.33333, -5];
+            var precision = 5;
+
+            for(var i = 0; i < actual.length; i++) {
+                expect(actual[i]).toBeCloseTo(expected[i], precision);
+            }
+        });
+    });
+
+    describe('percentile', function() {
+        it('finds the correct percentiles with the given dataset', function() {
+            var data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var expected = [2.5, 5, 7.5];
+            var actual = [
+                Utils.percentile(data, 0.25),
+                Utils.percentile(data, 0.5),
+                Utils.percentile(data, 0.75)
+            ];
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('getPercentiles', function() {
+        it('finds the correct quintiles with a sorted dataset', function() {
+            var data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var percentiles = [0.05, 0.25, 0.5, 0.75, 0.95];
+            var expected = [0.5, 2.5, 5, 7.5, 9.5];
+            var actual = Utils.getPercentiles(data, percentiles);
+            expect(actual).toEqual(expected);
+        });
+
+        it('finds the correct quintiles with an unsorted dataset', function() {
+            var data = [4, 8, 2, 10, 1, 0, 6, 7, 5, 9, 3];
+            var percentiles = [0.05, 0.25, 0.5, 0.75, 0.95];
+            var expected = [0.5, 2.5, 5, 7.5, 9.5];
+            var actual = Utils.getPercentiles(data, percentiles);
+            expect(actual).toEqual(expected)
+        });
+    });
 });


### PR DESCRIPTION
This PR adds the functionality to the UI to display z-scores (or other numeric information such as cell viability).

* On the database side of things, I've used the approach I described in #39 . An ``available_overlays`` array is populated in the ``Screen`` document that describes which overlays are available for the screen. If there's overlays available, the Flask template renders the dropdown menu. No menu is rendered if no screen overlay info is available so the UI just behaves as it did before. :)
* I was going to add support for Date/Time information, but all the images for Keefe's screen were either all done on the same date or the same date just got added to each plate. I think it'll be worthwhile to have this once we have a screen where date information is available though.
* I added two functions for calculating percentiles but didn't end up using them in the end. They're elegant af and could end up being useful. Don't mind removing them if you're not keen on unused code though!
* The upper and lower limits for the score colour scale is defined as config variable that forces the range [-4, 4]. Any values above or below that will be clamped to the min/max respectively. I wasn't quite sure how to handle this. I was going to use the 5th and 95th percentiles to calculate the upper and lower limits but it made the diverging scales look like ass because 0 wouldn't map to the "middle" neutral colour. Do you have any suggestions?
* Colour scales supported are magma, inferno, viridis and plasma from the new matplotlib scales.